### PR TITLE
fix(ci): replace invalid job-level secrets gate with step-level gate in commercial-backup.yml

### DIFF
--- a/.github/workflows/commercial-backup.yml
+++ b/.github/workflows/commercial-backup.yml
@@ -10,8 +10,6 @@ permissions:
 
 jobs:
   backup:
-    # Skip silently when production secrets are not yet configured (pre-GA repos).
-    if: ${{ secrets.ENGRAPHIS_CUSTOMER_URL != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -22,7 +20,17 @@ jobs:
       LICENSE_URL: ${{ secrets.ENGRAPHIS_LICENSE_URL }}
       VENDOR_TOKEN: ${{ secrets.ENGRAPHIS_VENDOR_ADMIN_TOKEN }}
     steps:
+      - name: Gate on secret availability
+        id: gate
+        run: |
+          if [ -z "$CUSTOMER_URL" ] || [ -z "$CUSTOMER_TOKEN" ] || [ -z "$LICENSE_URL" ] || [ -z "$VENDOR_TOKEN" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Commercial backup skipped — production secrets not yet configured (pre-GA)."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Require production backup targets
+        if: steps.gate.outputs.skip != 'true'
         run: |
           test -n "$CUSTOMER_URL"
           test -n "$CUSTOMER_TOKEN"
@@ -31,16 +39,19 @@ jobs:
           case "$CUSTOMER_URL" in https://*) ;; *) echo "customer URL must use HTTPS"; exit 1;; esac
           case "$LICENSE_URL" in https://*) ;; *) echo "license URL must use HTTPS"; exit 1;; esac
       - name: Back up managed customer service
+        if: steps.gate.outputs.skip != 'true'
         run: |
           printf 'Authorization: Bearer %s\n' "$CUSTOMER_TOKEN" |
             curl --fail --silent --show-error --max-time 300 --proto '=https' \
               -X POST --header @- --url "${CUSTOMER_URL%/}/api/ops/backup"
       - name: Back up license control plane
+        if: steps.gate.outputs.skip != 'true'
         run: |
           printf 'Authorization: Bearer %s\n' "$VENDOR_TOKEN" |
             curl --fail --silent --show-error --max-time 300 --proto '=https' \
               -X POST --header @- --url "${LICENSE_URL%/}/ops/backup"
       - name: Require fresh readiness after backup
+        if: steps.gate.outputs.skip != 'true'
         run: |
           printf 'Authorization: Bearer %s\n' "$CUSTOMER_TOKEN" |
             curl --fail --silent --show-error --max-time 20 --proto '=https' \


### PR DESCRIPTION
GitHub Actions does not support the `secrets` context in job-level `if` expressions, causing the workflow to fail every scheduled run. Replace with the same step-level gate pattern used in `production-synthetics.yml`: a dedicated gate step checks env vars and sets `skip=true` when secrets are unconfigured (pre-GA), with all subsequent steps conditioned on `steps.gate.outputs.skip != 'true'`.