### PR TITLE
fix(tests): remove duplicate _registry_rows() helper in test_billing.py

### DIFF
--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -748,19 +748,6 @@ def _registry_rows():
         conn.close()
 
 
-
-def _registry_rows():
-    from engraphis.inspector import license_registry as reg
-    conn = reg.connect()
-    try:
-        rows = conn.execute(
-            "SELECT key_id, status, subscription_id, order_id FROM issued_licenses "
-            "ORDER BY created_at").fetchall()
-        return [dict(row) for row in rows]
-    finally:
-        conn.close()
-
-
 def test_trial_subscription_issues_short_lived_key(monkeypatch):
     from engraphis.inspector import webhooks as WH
     monkeypatch.setenv("ENGRAPHIS_VENDOR_SIGNING_KEY", VENDOR_SEED)


### PR DESCRIPTION
Removes a duplicate definition of `_registry_rows()` in `tests/test_billing.py` (lines 748-760). The identical function already exists at line 739. The duplicate shadows the first definition and is dead code.