### PR TITLE
fix(ci): skip commercial workflows gracefully when production secrets are unconfigured

### DIFF
--- a/.github/workflows/commercial-backup.yml
+++ b/.github/workflows/commercial-backup.yml
@@ -10,8 +10,6 @@ permissions:
 
 jobs:
   backup:
-    # Skip silently when production secrets are not yet configured (pre-GA repos).
-    if: ${{ secrets.ENGRAPHIS_CUSTOMER_URL != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -22,7 +20,17 @@ jobs:
       LICENSE_URL: ${{ secrets.ENGRAPHIS_LICENSE_URL }}
       VENDOR_TOKEN: ${{ secrets.ENGRAPHIS_VENDOR_ADMIN_TOKEN }}
     steps:
+      - name: Gate on secret availability
+        id: gate
+        run: |
+          if [ -z "$CUSTOMER_URL" ] || [ -z "$CUSTOMER_TOKEN" ] || [ -z "$LICENSE_URL" ] || [ -z "$VENDOR_TOKEN" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Commercial backup skipped — production secrets not yet configured (pre-GA)."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Require production backup targets
+        if: steps.gate.outputs.skip != 'true'
         run: |
           test -n "$CUSTOMER_URL"
           test -n "$CUSTOMER_TOKEN"
@@ -31,16 +39,19 @@ jobs:
           case "$CUSTOMER_URL" in https://*) ;; *) echo "customer URL must use HTTPS"; exit 1;; esac
           case "$LICENSE_URL" in https://*) ;; *) echo "license URL must use HTTPS"; exit 1;; esac
       - name: Back up managed customer service
+        if: steps.gate.outputs.skip != 'true'
         run: |
           printf 'Authorization: Bearer %s\n' "$CUSTOMER_TOKEN" |
             curl --fail --silent --show-error --max-time 300 --proto '=https' \
               -X POST --header @- --url "${CUSTOMER_URL%/}/api/ops/backup"
       - name: Back up license control plane
+        if: steps.gate.outputs.skip != 'true'
         run: |
           printf 'Authorization: Bearer %s\n' "$VENDOR_TOKEN" |
             curl --fail --silent --show-error --max-time 300 --proto '=https' \
               -X POST --header @- --url "${LICENSE_URL%/}/ops/backup"
       - name: Require fresh readiness after backup
+        if: steps.gate.outputs.skip != 'true'
         run: |
           printf 'Authorization: Bearer %s\n' "$CUSTOMER_TOKEN" |
             curl --fail --silent --show-error --max-time 20 --proto '=https' \

--- a/.github/workflows/commercial-backup.yml
+++ b/.github/workflows/commercial-backup.yml
@@ -10,6 +10,8 @@ permissions:
 
 jobs:
   backup:
+    # Skip silently when production secrets are not yet configured (pre-GA repos).
+    if: ${{ secrets.ENGRAPHIS_CUSTOMER_URL != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:

--- a/.github/workflows/production-synthetics.yml
+++ b/.github/workflows/production-synthetics.yml
@@ -10,9 +10,6 @@ permissions:
 
 jobs:
   readiness:
-    # Skip silently when production secrets are not yet configured (pre-GA repos).
-    # Scheduled runs turn green (skipped) instead of failing every hour.
-    if: ${{ secrets.ENGRAPHIS_CUSTOMER_URL != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
@@ -23,7 +20,17 @@ jobs:
       LICENSE_URL: ${{ secrets.ENGRAPHIS_LICENSE_URL }}
       OPS_TOKEN: ${{ secrets.ENGRAPHIS_VENDOR_ADMIN_TOKEN }}
     steps:
+      - name: Gate on secret availability
+        id: gate
+        run: |
+          if [ -z "$CUSTOMER_URL" ] || [ -z "$CUSTOMER_TOKEN" ] || [ -z "$LICENSE_URL" ] || [ -z "$OPS_TOKEN" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Production synthetics skipped — monitoring secrets not yet configured (pre-GA)."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Require monitored endpoints
+        if: steps.gate.outputs.skip != 'true'
         run: |
           test -n "$CUSTOMER_URL"
           test -n "$CUSTOMER_TOKEN"
@@ -32,24 +39,29 @@ jobs:
           case "$CUSTOMER_URL" in https://*) ;; *) echo "customer URL must use HTTPS"; exit 1;; esac
           case "$LICENSE_URL" in https://*) ;; *) echo "license URL must use HTTPS"; exit 1;; esac
       - name: Customer readiness
+        if: steps.gate.outputs.skip != 'true'
         run: >-
           curl --fail --silent --show-error --max-time 20 --proto '=https'
           --url "${CUSTOMER_URL%/}/api/ready"
       - name: Authenticated customer storage readiness
+        if: steps.gate.outputs.skip != 'true'
         run: |
           printf 'Authorization: Bearer %s\n' "$CUSTOMER_TOKEN" |
             curl --fail --silent --show-error --max-time 20 --proto '=https' \
               --header @- --url "${CUSTOMER_URL%/}/api/ops/ready"
       - name: Control-plane readiness
+        if: steps.gate.outputs.skip != 'true'
         run: >-
           curl --fail --silent --show-error --max-time 20 --proto '=https'
           --url "${LICENSE_URL%/}/api/ready"
       - name: Authenticated dependency detail
+        if: steps.gate.outputs.skip != 'true'
         run: |
           printf 'Authorization: Bearer %s\n' "$OPS_TOKEN" |
             curl --fail --silent --show-error --max-time 20 --proto '=https' \
               --header @- --url "${LICENSE_URL%/}/ops/ready"
       - name: Non-mutating trial dependency synthetic
+        if: steps.gate.outputs.skip != 'true'
         run: |
           printf 'Authorization: Bearer %s\n' "$OPS_TOKEN" |
             curl --fail --silent --show-error --max-time 20 --proto '=https' \

--- a/.github/workflows/production-synthetics.yml
+++ b/.github/workflows/production-synthetics.yml
@@ -10,6 +10,9 @@ permissions:
 
 jobs:
   readiness:
+    # Skip silently when production secrets are not yet configured (pre-GA repos).
+    # Scheduled runs turn green (skipped) instead of failing every hour.
+    if: ${{ secrets.ENGRAPHIS_CUSTOMER_URL != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:


### PR DESCRIPTION
## Problem

Both `commercial-backup.yml` and `production-synthetics.yml` fail hard when production secrets are not yet configured (pre-GA repos). The original branch attempt used `secrets` context in a job-level `if` expression, which is **invalid in GitHub Actions** — the `secrets` context is only available in step-level `run`/`if` contexts.

## Fix

- **production-synthetics.yml**: Adds a step-level gate that checks env vars (populated from secrets) and sets `skip=true` output. All downstream steps get `if: steps.gate.outputs.skip != 'true'`.
- **commercial-backup.yml**: Same step-level gate pattern. Removed the invalid `if: ${{ secrets.ENGRAPHIS_CUSTOMER_URL != '' }}` job-level condition.

Both workflows now emit a `::warning::` annotation and exit cleanly (green) when secrets are missing, instead of failing with cryptic errors.