### PR TITLE
chore(railway): restore strict readiness gate

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
     "dockerfilePath": "Dockerfile"
   },
   "deploy": {
-    "healthcheckPath": "/api/health",
+    "healthcheckPath": "/api/ready",
     "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10


### PR DESCRIPTION
## Summary
- restore Railway healthchecks from the temporary liveness diagnostic to /api/ready`n- keep the five-minute startup window and existing restart policy unchanged

## Verification
- python -m pytest tests/test_release_infrastructure.py -q (6 passed)
- production /api/ready, authenticated ops readiness, encrypted backups, and trial synthetics were green before restoring the gate