### PR TITLE
fix(synthetics): keep rejection alert non-gating

### DIFF
--- a/engraphis/vendor_app.py
+++ b/engraphis/vendor_app.py
@@ -128,7 +128,12 @@ def create_app() -> FastAPI:
         trial_checks["email_worker"] = _email_worker_ok(app)
         trial_checks["public_url"] = bool(
             os.environ.get("ENGRAPHIS_RELAY_PUBLIC_URL", "").strip())
-        trial_checks["ready"] = all(trial_checks.values())
+        # Keep the public-rejection counter visible to monitoring, but do not make the
+        # synthetic attacker-controlled.  ``vendor_readiness`` applies the same rule:
+        # invalid lease attempts are an operator alert, not a serving dependency.
+        trial_checks["ready"] = all(
+            value for name, value in trial_checks.items()
+            if name != "rejected_leases")
         return JSONResponse(
             trial_checks, status_code=200 if trial_checks["ready"] else 503)
 

--- a/tests/test_commercial_ga.py
+++ b/tests/test_commercial_ga.py
@@ -379,6 +379,41 @@ def test_vendor_readiness_proves_matching_signer_but_honors_release_gate(
     assert operational["manual_fulfillment"] is True
 
 
+def test_trial_synthetic_reports_rejected_lease_alert_without_gating(monkeypatch):
+    from engraphis import vendor_app
+    from engraphis.config import settings
+
+    monkeypatch.setattr(settings, "service_mode", "vendor")
+    monkeypatch.setattr(vendor_app, "_admin_ok", lambda _request: True)
+    monkeypatch.setattr(vendor_app, "_email_worker_ok", lambda _app: True)
+    monkeypatch.setenv(
+        "ENGRAPHIS_RELAY_PUBLIC_URL", "https://license.engraphis.test")
+    checks = {
+        "signer": True,
+        "signer_release_ready": True,
+        "registry": True,
+        "email": True,
+        "email_webhook": True,
+        "email_outbox": True,
+        "polar_backlog": True,
+        "rejected_leases": False,
+        "disk": True,
+        "backup": True,
+        "ready": True,
+    }
+    monkeypatch.setattr(vendor_app, "vendor_readiness", lambda: checks.copy())
+    monkeypatch.setattr(
+        email_outbox, "process_due",
+        lambda *_args, **_kwargs: {"processed": 0, "sent": 0, "failed": 0})
+
+    with TestClient(vendor_app.create_app()) as client:
+        response = client.get("/ops/synthetic/trial")
+
+    assert response.status_code == 200
+    assert response.json()["rejected_leases"] is False
+    assert response.json()["ready"] is True
+
+
 def test_manual_fulfillment_fallback_is_an_authenticated_ops_alert(monkeypatch, tmp_path):
     from engraphis.inspector import webhooks
 


### PR DESCRIPTION
Keep the rejected-leases alert visible without letting attacker-controlled invalid attempts fail the dependency synthetic. This matches vendor readiness and adds a regression test. Verified with the commercial GA test module and ruff.