### PR TITLE
Improve graph communities and add memory demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,10 @@ internal/
 # venv. The portable, env-configurable equivalent is the tracked scripts/mcp_server_http.py.
 /engraphis-mcp-http.py
 
+# Generated screen-demo payload and encoded video.
+/demo/generated/
+/demo/output/
+
 # FUSE mount artifacts: orphaned unlink-while-open handles from the Cowork
 # mount layer, not real content. Safe to ignore; delete host-side once the
 # holding process releases the handle (rm from the sandbox gets EPERM).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to Engraphis are documented here. Format loosely follows
 
 ### Changed
 
+- The legacy graph view now defaults to deterministic community islands, keeps sparse
+  influence bridges visually subordinate, and renders bounded direct A-MEM links even when
+  entity extraction is disabled. A reproducible repository-local screen-demo workflow exercises
+  session handoff, bi-temporal supersession, recall evidence, and history without external
+  services.
 - The public distribution is now structurally customer-only. License issuance, billing,
   fulfillment, Team identity, hosted relay, managed compute, worker execution, vendor
   administration, and commercial operations tooling moved to a private service repository;

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,29 @@
+# Engraphis memory-continuity screen demo
+
+This produces a silent 56-second MP4 showing the three proof points requested:
+
+1. A new `demo-agent` session boots from the previous repository handoff and recalls the v2 architecture context.
+2. A same-subject fact changes; the resolver invalidates the old row while preserving it in history.
+3. Retrieval evidence sits next to the Timeline chain, showing the retrieval arm, fused score, retention, provenance, and current/past validity.
+
+The payload is generated from a real in-memory `MemoryService` run before recording. No credentials, live services, or external APIs are used.
+
+Install the repository's Node dependencies and Chromium once, and ensure `ffmpeg` is on `PATH`:
+
+```powershell
+npm ci
+npx playwright install chromium
+ffmpeg -version
+```
+
+From the repository root:
+
+```powershell
+node demo/record_screen_demo.mjs
+```
+
+The finished video is written to `demo/output/engraphis-memory-demo.mp4`. To inspect only the data contract:
+
+```powershell
+python demo/prepare_screen_demo.py
+```

--- a/demo/engraphis_screen_demo.html
+++ b/demo/engraphis_screen_demo.html
@@ -1,0 +1,279 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Engraphis · memory continuity demo</title>
+  <style>
+    :root {
+      --ink: #eff2f6;
+      --muted: #9da8b6;
+      --faint: #687585;
+      --canvas: #090d12;
+      --panel: rgba(18, 25, 34, .93);
+      --panel-2: rgba(24, 33, 44, .9);
+      --line: rgba(170, 192, 214, .16);
+      --violet: #a78bfa;
+      --cyan: #67e8f9;
+      --green: #6ee7b7;
+      --amber: #fbbf72;
+      --red: #fb7185;
+      --shadow: 0 22px 70px rgba(0, 0, 0, .42);
+    }
+    * { box-sizing: border-box; }
+    html, body { width: 100%; height: 100%; margin: 0; }
+    body {
+      overflow: hidden;
+      color: var(--ink);
+      background:
+        radial-gradient(circle at 78% 18%, rgba(103, 232, 249, .12), transparent 32%),
+        radial-gradient(circle at 12% 78%, rgba(167, 139, 250, .13), transparent 35%),
+        var(--canvas);
+      font: 15px/1.45 Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      letter-spacing: .01em;
+    }
+    body::before {
+      position: fixed; inset: 0; content: ""; pointer-events: none; opacity: .22;
+      background-image: linear-gradient(rgba(255,255,255,.035) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255,255,255,.035) 1px, transparent 1px);
+      background-size: 42px 42px;
+      mask-image: linear-gradient(to bottom, black, transparent 95%);
+    }
+    .frame { position: relative; width: 100vw; height: 100vh; padding: 30px 48px; }
+    .topbar { height: 42px; display: flex; justify-content: space-between; align-items: center; color: var(--muted); }
+    .brand { display: flex; align-items: center; gap: 11px; text-transform: uppercase; font-size: 12px; letter-spacing: .18em; }
+    .mark { width: 22px; height: 22px; position: relative; border: 1px solid rgba(167,139,250,.7); border-radius: 7px; transform: rotate(45deg); }
+    .mark::after { content: ""; position: absolute; inset: 5px; border: 1px solid rgba(103,232,249,.9); border-radius: 3px; }
+    .top-meta { display: flex; gap: 10px; align-items: center; font-size: 11px; letter-spacing: .1em; text-transform: uppercase; }
+    .live-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--green); box-shadow: 0 0 16px var(--green); }
+    .pill { display: inline-flex; align-items: center; gap: 7px; border: 1px solid var(--line); border-radius: 999px; padding: 5px 10px; color: var(--muted); background: rgba(255,255,255,.025); font-size: 11px; white-space: nowrap; }
+    .pill.violet { color: #d9ccff; border-color: rgba(167,139,250,.38); background: rgba(167,139,250,.09); }
+    .pill.cyan { color: #b9f7ff; border-color: rgba(103,232,249,.38); background: rgba(103,232,249,.08); }
+    .pill.green { color: #bbf7de; border-color: rgba(110,231,183,.38); background: rgba(110,231,183,.08); }
+    .pill.amber { color: #ffe2b2; border-color: rgba(251,191,114,.38); background: rgba(251,191,114,.08); }
+    .stage { position: absolute; top: 92px; right: 48px; bottom: 26px; left: 48px; }
+    .scene { position: absolute; inset: 0; display: flex; flex-direction: column; opacity: 0; transform: translateY(16px) scale(.985); pointer-events: none; transition: opacity .62s ease, transform .62s ease; }
+    .scene.active { opacity: 1; transform: none; pointer-events: auto; }
+    .scene.active .reveal { animation: rise .55s cubic-bezier(.2,.8,.2,1) both; }
+    .scene.active .reveal:nth-child(2) { animation-delay: .1s; }
+    .scene.active .reveal:nth-child(3) { animation-delay: .2s; }
+    .scene.active .reveal:nth-child(4) { animation-delay: .3s; }
+    .scene.active .reveal:nth-child(5) { animation-delay: .4s; }
+    @keyframes rise { from { opacity: 0; transform: translateY(13px); } to { opacity: 1; transform: none; } }
+    @keyframes blink { 0%, 100% { opacity: .3; } 50% { opacity: 1; } }
+    @keyframes pulse { 0%, 100% { box-shadow: 0 0 0 0 rgba(110,231,183,.08); } 50% { box-shadow: 0 0 0 10px rgba(110,231,183,0); } }
+    .kicker { color: var(--cyan); font-size: 11px; letter-spacing: .22em; text-transform: uppercase; }
+    h1, h2, p { margin: 0; }
+    h1 { font-size: clamp(38px, 5vw, 70px); line-height: 1.02; letter-spacing: -.045em; font-weight: 650; }
+    h1 em { color: var(--violet); font-style: normal; }
+    h2 { font-size: 31px; line-height: 1.08; letter-spacing: -.03em; font-weight: 620; }
+    .sub { max-width: 570px; color: var(--muted); font-size: 17px; }
+    .intro { justify-content: center; padding-left: 9vw; gap: 24px; }
+    .intro h1 { max-width: 780px; }
+    .intro .sub { max-width: 555px; }
+    .intro-footer { display: flex; gap: 9px; margin-top: 10px; }
+    .scene-head { display: flex; justify-content: space-between; align-items: end; margin-bottom: 24px; }
+    .scene-head .sub { max-width: 440px; font-size: 14px; text-align: right; }
+    .split { min-height: 0; flex: 1; display: grid; grid-template-columns: .78fr 1.22fr; gap: 22px; }
+    .split.equal { grid-template-columns: 1fr 1fr; }
+    .copy { display: flex; flex-direction: column; gap: 17px; padding: 24px 8px 0 0; }
+    .copy h2 { max-width: 440px; }
+    .copy .sub { font-size: 15px; max-width: 420px; }
+    .surface { min-height: 0; border: 1px solid var(--line); border-radius: 18px; background: var(--panel); box-shadow: var(--shadow); overflow: hidden; }
+    .terminal { display: flex; flex-direction: column; }
+    .surface-bar { height: 44px; display: flex; align-items: center; justify-content: space-between; padding: 0 16px; border-bottom: 1px solid var(--line); background: rgba(255,255,255,.025); color: var(--faint); font-size: 11px; letter-spacing: .1em; text-transform: uppercase; }
+    .window-dots { display: flex; gap: 6px; }
+    .window-dots i { width: 7px; height: 7px; border-radius: 50%; background: #455363; }
+    .window-dots i:first-child { background: #fb7185; }
+    .window-dots i:nth-child(2) { background: #fbbf72; }
+    .window-dots i:nth-child(3) { background: #6ee7b7; }
+    .terminal-body { padding: 23px 24px 25px; display: flex; flex-direction: column; gap: 11px; font: 13px/1.5 "SFMono-Regular", Consolas, "Liberation Mono", monospace; }
+    .prompt { color: var(--cyan); }
+    .output { color: #d4dae3; padding-left: 17px; border-left: 1px solid rgba(103,232,249,.3); }
+    .output strong { color: var(--green); font-weight: 500; }
+    .output em { color: var(--amber); font-style: normal; }
+    .handoff { margin: 4px 0 2px 17px; padding: 12px 14px; border-radius: 10px; background: rgba(167,139,250,.08); border: 1px solid rgba(167,139,250,.24); color: #d9d0f8; }
+    .handoff .label { color: var(--violet); font-size: 10px; text-transform: uppercase; letter-spacing: .12em; }
+    .result { margin-top: 3px; padding: 14px; border-radius: 10px; border: 1px solid rgba(110,231,183,.27); background: rgba(110,231,183,.06); }
+    .result-title { display: flex; justify-content: space-between; gap: 15px; color: #eafdf5; font-weight: 600; }
+    .result-copy { color: #b7c1cc; margin-top: 7px; }
+    .micro { color: var(--faint); font-size: 11px; }
+    .thread-row { display: flex; flex-wrap: wrap; gap: 7px; margin: 2px 0 0 17px; }
+    .thread { padding: 4px 8px; border: 1px solid rgba(251,191,114,.27); color: #f8d8a6; border-radius: 6px; font-size: 11px; }
+    .change-grid { display: grid; grid-template-columns: minmax(0, 1fr) 62px minmax(0, 1fr); gap: 14px; padding: 25px; }
+    .version { position: relative; padding: 18px; min-height: 190px; border: 1px solid var(--line); border-radius: 13px; background: rgba(255,255,255,.025); }
+    .version.current { border-color: rgba(110,231,183,.4); background: rgba(110,231,183,.055); }
+    .version.old { opacity: .66; }
+    .version-label { display: flex; justify-content: space-between; align-items: center; color: var(--muted); font-size: 11px; letter-spacing: .11em; text-transform: uppercase; }
+    .version p { margin-top: 20px; font-size: 17px; line-height: 1.35; }
+    .version.old p { text-decoration: line-through; text-decoration-color: rgba(251,113,133,.66); }
+    .version .time { position: absolute; bottom: 15px; left: 18px; color: var(--faint); font-size: 11px; }
+    .arrow { align-self: center; color: var(--violet); font-size: 22px; }
+    .resolver { grid-column: 1 / -1; display: grid; grid-template-columns: 160px 1fr; align-items: center; gap: 14px; padding: 13px 15px; border-radius: 10px; border: 1px solid rgba(167,139,250,.24); background: rgba(167,139,250,.06); }
+    .resolver-label { color: var(--violet); font-size: 10px; letter-spacing: .13em; text-transform: uppercase; }
+    .resolver-copy { color: #d5dbe3; font: 12px/1.5 "SFMono-Regular", Consolas, monospace; }
+    .guard { display: flex; align-items: center; gap: 9px; color: var(--green); font-size: 12px; margin-top: auto; }
+    .guard::before { content: "✓"; display: grid; place-items: center; width: 20px; height: 20px; border: 1px solid rgba(110,231,183,.45); border-radius: 50%; animation: pulse 2s infinite; }
+    .explain-grid { min-height: 0; flex: 1; display: grid; grid-template-columns: 1fr .94fr; gap: 22px; }
+    .explain-card { padding: 23px; display: flex; flex-direction: column; gap: 17px; }
+    .explain-title { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
+    .explain-title h3 { margin: 0; font-size: 15px; letter-spacing: .09em; text-transform: uppercase; font-weight: 600; }
+    .query { color: var(--muted); font: 13px/1.5 "SFMono-Regular", Consolas, monospace; }
+    .why-result { padding: 15px; border: 1px solid rgba(110,231,183,.28); border-radius: 12px; background: rgba(110,231,183,.06); }
+    .why-result .title { color: #eafff6; font-weight: 650; }
+    .why-result p { color: #bbc5d0; margin-top: 7px; font-size: 14px; }
+    .evidence { display: grid; grid-template-columns: repeat(2, 1fr); gap: 9px; }
+    .evidence-item { padding: 11px 12px; border: 1px solid var(--line); border-radius: 9px; background: rgba(255,255,255,.025); }
+    .evidence-item .label { color: var(--faint); display: block; text-transform: uppercase; font-size: 9px; letter-spacing: .11em; }
+    .evidence-item .value { display: block; margin-top: 4px; color: var(--ink); font: 12px/1.4 "SFMono-Regular", Consolas, monospace; }
+    .explain-note { margin-top: auto; padding-top: 13px; border-top: 1px solid var(--line); color: var(--muted); font-size: 13px; }
+    .timeline-card { padding: 23px; overflow: auto; }
+    .timeline-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 19px; }
+    .timeline-head h3 { margin: 0; font-size: 15px; letter-spacing: .09em; text-transform: uppercase; font-weight: 600; }
+    .chain { position: relative; padding-left: 24px; }
+    .chain::before { position: absolute; content: ""; top: 9px; bottom: 9px; left: 5px; width: 1px; background: linear-gradient(var(--red), var(--green)); }
+    .node { position: relative; padding: 0 0 25px 14px; }
+    .node:last-child { padding-bottom: 0; }
+    .node::before { position: absolute; content: ""; left: -24px; top: 4px; width: 10px; height: 10px; border-radius: 50%; background: var(--red); box-shadow: 0 0 0 4px rgba(251,113,133,.11); }
+    .node.current::before { background: var(--green); box-shadow: 0 0 0 4px rgba(110,231,183,.12); }
+    .node-label { display: flex; justify-content: space-between; align-items: center; gap: 10px; color: #e7ebf0; font-size: 13px; font-weight: 600; }
+    .node-copy { margin-top: 6px; color: var(--muted); font-size: 13px; }
+    .node-meta { display: flex; gap: 7px; flex-wrap: wrap; margin-top: 10px; color: var(--faint); font: 10px "SFMono-Regular", Consolas, monospace; }
+    .node-meta span { padding: 4px 6px; border: 1px solid var(--line); border-radius: 5px; }
+    .close { justify-content: center; align-items: center; text-align: center; gap: 21px; }
+    .close h1 { max-width: 830px; }
+    .close .sub { max-width: 600px; }
+    .close-rule { width: 92px; height: 1px; background: linear-gradient(90deg, transparent, var(--cyan), transparent); }
+    .close-badges { display: flex; gap: 9px; }
+    .progress { position: fixed; left: 48px; right: 48px; bottom: 14px; height: 2px; background: rgba(255,255,255,.1); }
+    .progress > span { display: block; height: 100%; width: 0; background: linear-gradient(90deg, var(--violet), var(--cyan)); box-shadow: 0 0 10px rgba(103,232,249,.65); }
+    .timecode { min-width: 42px; text-align: right; color: var(--faint); font: 11px "SFMono-Regular", Consolas, monospace; }
+    @media (max-width: 980px) {
+      .frame { padding: 22px 24px; }
+      .stage { top: 77px; right: 24px; left: 24px; }
+      .split, .split.equal, .explain-grid { grid-template-columns: 1fr; }
+      .scene-head .sub { display: none; }
+      .copy { padding-top: 0; }
+      .surface { max-height: 60vh; }
+      .progress { left: 24px; right: 24px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="frame">
+    <header class="topbar">
+      <div class="brand"><span class="mark"></span><span>Engraphis</span><span style="color:var(--faint)">/</span><span>Memory continuity</span></div>
+      <div class="top-meta"><span class="live-dot"></span><span>local replay</span><span class="pill violet">56 sec</span><span id="timecode" class="timecode">00:00</span></div>
+    </header>
+    <main class="stage">
+      <section class="scene intro active" data-scene="intro">
+        <div class="kicker reveal">A screen demo for coding agents</div>
+        <h1 class="reveal">Memory that survives<br><em>the next session.</em></h1>
+        <p class="sub reveal">An agent resumes repository context, updates a fact without erasing its past, then traces exactly why that context came back.</p>
+        <div class="intro-footer reveal"><span class="pill cyan">scoped</span><span class="pill violet">bi-temporal</span><span class="pill green">local-first</span></div>
+      </section>
+
+      <section class="scene" data-scene="session">
+        <div class="scene-head reveal"><div><div class="kicker">01 / start a session</div><h2>The agent resumes with context.</h2></div><p class="sub">A new session gets the last handoff before it asks the repository the first question.</p></div>
+        <div class="split">
+          <div class="copy reveal"><span class="pill violet" style="width:max-content">workspace / <b>default</b></span><span class="pill cyan" style="width:max-content">repo / <b>engraphis</b></span><p class="sub">The memory boundary is explicit. The agent does not start from an empty prompt or a flat namespace.</p><div class="guard">session scope and repository scope stay visible</div></div>
+          <div class="surface terminal reveal"><div class="surface-bar"><span class="window-dots"><i></i><i></i><i></i></span><span>agent console · demo-agent</span><span class="pill green">active</span></div><div class="terminal-body">
+            <div><span class="prompt">$</span> engraphis_start_session(<span style="color:var(--amber)">repo="engraphis"</span>)</div>
+            <div class="output"><strong>✓ new session</strong> · <span data-session-id>ses_01…</span></div>
+            <div class="handoff"><div class="label">bootstrap handoff</div><div data-bootstrap>v2 is the current scoped, bi-temporal architecture.</div></div>
+            <div class="output"><span style="color:var(--violet)">open thread</span> · <span data-open-thread>Show why the architecture context was retrieved.</span></div>
+            <div style="margin-top:5px"><span class="prompt">$</span> engraphis_recall(<span style="color:var(--amber)">"where should new capability live?"</span>)</div>
+            <div class="result"><div class="result-title"><span data-recall-title>Where to build</span><span class="pill green">recalled</span></div><div class="result-copy" data-recall-content>New capability belongs in core and backends.</div><div class="micro" style="margin-top:9px" data-recall-why>Matched by semantic retrieval · fused score 4.190 · retention 1.000</div></div>
+          </div></div>
+        </div>
+      </section>
+
+      <section class="scene" data-scene="change">
+        <div class="scene-head reveal"><div><div class="kicker">02 / change a fact</div><h2>Updates close the old truth.<br><em>They do not delete it.</em></h2></div><p class="sub">The resolver records an explicit supersession edge and leaves the prior version inspectable.</p></div>
+        <div class="surface reveal"><div class="surface-bar"><span>memory editor · Demo configuration</span><span class="pill amber">resolver activity</span></div><div class="change-grid">
+          <article class="version old"><div class="version-label"><span>past version</span><span class="pill amber">closed</span></div><p data-old-content>The screen demo records against the standard dashboard port 8700.</p><span class="time" data-old-time>valid until this update</span></article>
+          <div class="arrow">→</div>
+          <article class="version current"><div class="version-label"><span>current version</span><span class="pill green">live</span></div><p data-current-content>The screen demo records against port 8790 so it does not collide with a developer dashboard.</p><span class="time" data-current-time>valid now</span></article>
+          <div class="resolver"><div class="resolver-label">write-path decision</div><div class="resolver-copy"><span style="color:var(--green)">invalidate</span> · <span data-resolution>same subject detected; previous memory preserved in history</span></div></div>
+        </div></div>
+        <div class="guard reveal">one fact, two versions, one explainable chain</div>
+      </section>
+
+      <section class="scene" data-scene="explain">
+        <div class="scene-head reveal"><div><div class="kicker">03 / explain the answer</div><h2>Engraphis can show<br><em>why it retrieved context.</em></h2></div><p class="sub">Retrieval evidence and bi-temporal history sit beside each other, not hidden behind a black box.</p></div>
+        <div class="explain-grid">
+          <div class="surface explain-card reveal"><div class="explain-title"><h3>Why this was retrieved</h3><span class="pill cyan">recall evidence</span></div><div class="query" data-query>query: where should new Engraphis capability live?</div><div class="why-result"><div class="title" data-recall-title>Where to build</div><p data-recall-content>New capability belongs in core and backends.</p></div><div class="evidence"><div class="evidence-item"><span class="label">retrieval arm</span><span class="value" data-arm>semantic</span></div><div class="evidence-item"><span class="label">fused score</span><span class="value" data-score>4.190</span></div><div class="evidence-item"><span class="label">retention</span><span class="value" data-retention>1.000</span></div><div class="evidence-item"><span class="label">provenance</span><span class="value" data-provenance>demo-seed · trusted</span></div></div><p class="explain-note">The agent gets the answer, the score signal, and the source that produced it.</p></div>
+          <div class="surface timeline-card reveal"><div class="timeline-head"><h3>Timeline / Demo configuration</h3><span class="pill violet">history preserved</span></div><div class="chain" data-timeline><div class="node"><div class="node-label"><span>Past version</span><span class="pill amber">past</span></div><div class="node-copy">The standard dashboard port was 8700.</div><div class="node-meta"><span>valid time · closed</span><span>source · demo-seed</span></div></div><div class="node current"><div class="node-label"><span>Current version</span><span class="pill green">current</span></div><div class="node-copy">The demo uses 8790 to avoid a collision.</div><div class="node-meta"><span>valid time · current</span><span>source · demo-seed</span></div></div></div></div>
+        </div>
+      </section>
+
+      <section class="scene close" data-scene="close">
+        <div class="kicker reveal">A paper trail for agent memory</div>
+        <h1 class="reveal">Recall the context.<br><em>Keep the history.</em></h1>
+        <div class="close-rule reveal"></div>
+        <p class="sub reveal">Engraphis makes memory scoped, temporal, and explainable across sessions and repositories.</p>
+        <div class="close-badges reveal"><span class="pill violet">what the agent knows</span><span class="pill cyan">why it knows it</span><span class="pill green">how it changed</span></div>
+      </section>
+    </main>
+    <div class="progress"><span id="progress"></span></div>
+  </div>
+  <script>
+    const FALLBACK = {
+      session: { session_id: "ses_01DEMOSESSION", bootstrap: { summary: "v2 is the current scoped, bi-temporal architecture: build new capability in engraphis/core and engraphis/backends.", open_threads: ["Show why the architecture context was retrieved."] } },
+      recall: { query: "where should new Engraphis capability live?", memory: { title: "Where to build", content: "New Engraphis capability belongs in engraphis/core and engraphis/backends; engraphis/app.py is the v1 legacy reference server.", score: 4.1896, retention: 1, arm: "semantic", why_recalled: "Matched by semantic retrieval; fused score 4.190, retention 1.000.", provenance: { source: "demo-seed", trusted: true } } },
+      why: { current: { content: "The screen demo records against port 8790 so it does not collide with a developer dashboard." }, supersedes: [{ content: "The screen demo records against the standard dashboard port 8700." }] },
+      timeline: [{ content: "The screen demo records against the standard dashboard port 8700.", valid_to: 1 }, { content: "The screen demo records against port 8790 so it does not collide with a developer dashboard.", valid_to: null }],
+      inspection: { events: [{ action: "invalidate", detail: "superseded prior version" }] }
+    };
+    const esc = (value) => String(value ?? "").replace(/[&<>"']/g, (char) => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[char]));
+    const shortId = (value) => value ? value.slice(0, 18) + "…" : "ses_01…";
+    const text = (selector, value) => { const node = document.querySelector(selector); if (node) node.textContent = value ?? ""; };
+    function hydrate(data) {
+      const session = data.session || FALLBACK.session;
+      const recall = data.recall || FALLBACK.recall;
+      const memory = recall.memory || FALLBACK.recall.memory;
+      const timeline = data.timeline || FALLBACK.timeline;
+      const old = timeline[0] || FALLBACK.timeline[0];
+      const current = timeline[timeline.length - 1] || FALLBACK.timeline[1];
+      text("[data-session-id]", shortId(session.session_id));
+      text("[data-bootstrap]", session.bootstrap?.summary);
+      text("[data-open-thread]", (session.bootstrap?.open_threads || [])[0]);
+      document.querySelectorAll("[data-recall-title]").forEach((node) => node.textContent = memory.title || "Where to build");
+      document.querySelectorAll("[data-recall-content]").forEach((node) => node.textContent = memory.content || "");
+      text("[data-recall-why]", memory.why_recalled || "Matched by semantic retrieval");
+      text("[data-old-content]", old.content);
+      text("[data-current-content]", current.content);
+      const event = (data.inspection?.events || [])[0];
+      text("[data-resolution]", event?.detail || "same subject detected; previous memory preserved in history");
+      text("[data-query]", "query: " + (recall.query || FALLBACK.recall.query));
+      text("[data-arm]", memory.arm || "semantic");
+      text("[data-score]", memory.score != null ? Number(memory.score).toFixed(3) : "4.190");
+      text("[data-retention]", memory.retention != null ? Number(memory.retention).toFixed(3) : "1.000");
+      text("[data-provenance]", `${memory.provenance?.source || "demo-seed"} · ${memory.provenance?.trusted === false ? "untrusted" : "trusted"}`);
+      const chain = document.querySelector("[data-timeline]");
+      if (chain) chain.innerHTML = timeline.map((item) => { const past = item.valid_to != null || item.expired_at != null; return `<div class="node${past ? "" : " current"}"><div class="node-label"><span>${past ? "Past version" : "Current version"}</span><span class="pill ${past ? "amber" : "green"}">${past ? "past" : "current"}</span></div><div class="node-copy">${esc(item.content)}</div><div class="node-meta"><span>valid time · ${past ? "closed" : "current"}</span><span>source · ${esc(item.provenance?.source || "demo-seed")}</span></div></div>`; }).join("");
+    }
+    fetch("generated/screen_demo_payload.json").then((response) => response.ok ? response.json() : Promise.reject(new Error("payload unavailable"))).then(hydrate).catch(() => hydrate(FALLBACK));
+
+    const TOTAL = 56;
+    const scenes = [
+      ["intro", 0, 5.5], ["session", 5.5, 22], ["change", 22, 38.5], ["explain", 38.5, 53.5], ["close", 53.5, 56]
+    ];
+    let start = performance.now();
+    let lastScene = "";
+    function tick(now) {
+      const elapsed = Math.min((now - start) / 1000, TOTAL);
+      const active = scenes.find(([name, from, to]) => elapsed >= from && elapsed < to) || scenes[scenes.length - 1];
+      if (active[0] !== lastScene) {
+        document.querySelectorAll(".scene").forEach((scene) => scene.classList.toggle("active", scene.dataset.scene === active[0]));
+        lastScene = active[0];
+      }
+      document.getElementById("progress").style.width = `${(elapsed / TOTAL) * 100}%`;
+      document.getElementById("timecode").textContent = `00:${String(Math.floor(elapsed)).padStart(2, "0")}`;
+      if (elapsed >= TOTAL) { window.demoDone = true; return; }
+      requestAnimationFrame(tick);
+    }
+    requestAnimationFrame(tick);
+  </script>
+</body>
+</html>

--- a/demo/prepare_screen_demo.py
+++ b/demo/prepare_screen_demo.py
@@ -1,0 +1,161 @@
+"""Seed a real in-memory Engraphis flow and export the screen-demo payload.
+
+The recording is intentionally short and deterministic at the UI level, but its
+claims come from the v1 service facade used by the dashboard: a previous session
+is ended, a new one boots from that handoff, a same-subject fact is superseded,
+and the resulting recall/why/timeline/inspect responses are exported for the
+visual layer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from engraphis.service import MemoryService
+
+
+WORKSPACE = "default"
+REPO = "engraphis"
+AGENT = "demo-agent"
+
+
+def build_payload() -> dict:
+    svc = MemoryService.create(":memory:", embed_model="")
+
+    seeded = svc.start_session(
+        WORKSPACE,
+        repo=REPO,
+        agent=AGENT,
+        goal="Seed the continuity story for the screen demo",
+    )
+    svc.end_session(
+        seeded["session_id"],
+        summary=(
+            "v2 is the current scoped, bi-temporal architecture: build new capability "
+            "in engraphis/core and engraphis/backends. The dashboard exposes recall "
+            "and history."
+        ),
+        outcome="Seeded the handoff for the next agent session.",
+        open_threads=["Show why the architecture context was retrieved."],
+    )
+
+    session = svc.start_session(
+        WORKSPACE,
+        repo=REPO,
+        agent=AGENT,
+        goal="Record the 56-second memory continuity demo",
+    )
+    assert session["bootstrap"]["summary"], "new session did not receive a handoff"
+
+    architecture = svc.remember(
+        (
+            "New Engraphis capability belongs in engraphis/core and engraphis/backends; "
+            "engraphis/app.py is the v1 legacy reference server."
+        ),
+        workspace=WORKSPACE,
+        repo=REPO,
+        session_id=session["session_id"],
+        title="Where to build",
+        importance=0.95,
+        source="demo-seed",
+        kind="demo_fixture",
+    )
+
+    old_endpoint = svc.remember(
+        "The screen demo records against the standard dashboard port 8700.",
+        workspace=WORKSPACE,
+        repo=REPO,
+        session_id=session["session_id"],
+        title="Demo configuration",
+        importance=0.80,
+        source="demo-seed",
+        kind="demo_fixture",
+    )
+    current_endpoint = svc.remember(
+        (
+            "The screen demo records against port 8790 so it does not collide with "
+            "a developer dashboard."
+        ),
+        workspace=WORKSPACE,
+        repo=REPO,
+        session_id=session["session_id"],
+        title="Demo configuration",
+        importance=0.90,
+        source="demo-seed",
+        kind="demo_fixture",
+    )
+    assert current_endpoint["op"] == "invalidate", current_endpoint
+
+    recall = svc.recall(
+        "where should new Engraphis capability live?",
+        workspace=WORKSPACE,
+        repo=REPO,
+        k=5,
+        reinforce=False,
+    )
+    assert recall["count"] >= 1, "architecture context was not recallable"
+    recalled = next(
+        (memory for memory in recall["memories"] if memory["id"] == architecture["id"]),
+        None,
+    )
+    assert recalled is not None, recall
+
+    why = svc.why("demo configuration", workspace=WORKSPACE, repo=REPO)
+    timeline = svc.timeline("demo configuration", workspace=WORKSPACE, repo=REPO)
+    inspected = svc.inspect(
+        current_endpoint["id"], workspace=WORKSPACE, repo=REPO
+    )
+    history = timeline["history"]
+    past = next(
+        (item for item in history if item["valid_to"] is not None or item["expired_at"] is not None),
+        None,
+    )
+    live = next(
+        (item for item in history if item["valid_to"] is None and item["expired_at"] is None),
+        None,
+    )
+    assert len(why["supersedes"]) == 1, why
+    assert why["supersedes"][0]["id"] == old_endpoint["id"], why
+    assert len(history) == 2, timeline
+    assert len(inspected["chain"]) == 2, inspected
+    assert past is not None, timeline
+    assert live is not None, timeline
+
+    return {
+        "workspace": WORKSPACE,
+        "repo": REPO,
+        "session": session,
+        "recall": {
+            "query": recall["query"],
+            "memory": recalled,
+        },
+        "why": {
+            "current": why["answer"][0],
+            "supersedes": why["supersedes"],
+        },
+        "timeline": [past, live],
+        "inspection": {
+            "chain": inspected["chain"],
+            "events": [event for item in inspected["chain"] for event in item["events"]],
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        default="demo/generated/screen_demo_payload.json",
+        help="JSON payload path (created at runtime; ignored by git).",
+    )
+    args = parser.parse_args()
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(build_payload(), indent=2), encoding="utf-8")
+    print(f"Prepared screen-demo payload: {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/record_screen_demo.mjs
+++ b/demo/record_screen_demo.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { chromium } from "playwright";
 
 const demoDir = resolve(fileURLToPath(new URL(".", import.meta.url)));
+const repoRoot = resolve(demoDir, "..");
 const generatedDir = join(demoDir, "generated");
 const outputDir = join(demoDir, "output");
 const payload = join(generatedDir, "screen_demo_payload.json");
@@ -16,8 +17,8 @@ const port = 8790;
 mkdirSync(generatedDir, { recursive: true });
 mkdirSync(outputDir, { recursive: true });
 const prepared = spawnSync(process.env.PYTHON || "python", [
-  join(demoDir, "prepare_screen_demo.py"), "--output", payload,
-], { cwd: resolve(demoDir, ".."), stdio: "inherit" });
+  "-m", "demo.prepare_screen_demo", "--output", payload,
+], { cwd: repoRoot, stdio: "inherit" });
 if (prepared.status !== 0) process.exit(prepared.status || 1);
 
 const server = createServer((request, response) => {

--- a/demo/record_screen_demo.mjs
+++ b/demo/record_screen_demo.mjs
@@ -1,0 +1,71 @@
+import { spawn, spawnSync } from "node:child_process";
+import { createReadStream, mkdirSync, rmSync, statSync } from "node:fs";
+import { createServer } from "node:http";
+import { join, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const demoDir = resolve(fileURLToPath(new URL(".", import.meta.url)));
+const generatedDir = join(demoDir, "generated");
+const outputDir = join(demoDir, "output");
+const payload = join(generatedDir, "screen_demo_payload.json");
+const webm = join(outputDir, "engraphis-memory-demo.webm");
+const mp4 = join(outputDir, "engraphis-memory-demo.mp4");
+const port = 8790;
+
+mkdirSync(generatedDir, { recursive: true });
+mkdirSync(outputDir, { recursive: true });
+const prepared = spawnSync(process.env.PYTHON || "python", [
+  join(demoDir, "prepare_screen_demo.py"), "--output", payload,
+], { cwd: resolve(demoDir, ".."), stdio: "inherit" });
+if (prepared.status !== 0) process.exit(prepared.status || 1);
+
+const server = createServer((request, response) => {
+  let relative;
+  try {
+    relative = decodeURIComponent((request.url || "/").split("?", 1)[0]);
+  } catch {
+    response.writeHead(400); response.end("Bad request"); return;
+  }
+  const requested = relative === "/" ? "engraphis_screen_demo.html" : relative.slice(1);
+  const file = resolve(demoDir, requested);
+  if (file !== demoDir && !file.startsWith(demoDir + sep)) {
+    response.writeHead(403); response.end("Forbidden"); return;
+  }
+  try {
+    const stat = statSync(file);
+    response.writeHead(200, { "Content-Length": stat.size, "Content-Type": file.endsWith(".json") ? "application/json" : "text/html" });
+    createReadStream(file).pipe(response);
+  } catch {
+    response.writeHead(404); response.end("Not found");
+  }
+});
+await new Promise((resolveServer) => server.listen(port, "127.0.0.1", resolveServer));
+
+const browser = await chromium.launch({ headless: true });
+const context = await browser.newContext({
+  viewport: { width: 1920, height: 1080 },
+  recordVideo: { dir: outputDir, size: { width: 1920, height: 1080 } },
+  deviceScaleFactor: 1,
+});
+const page = await context.newPage();
+await page.goto(`http://127.0.0.1:${port}/engraphis_screen_demo.html?autoplay=1`, { waitUntil: "networkidle" });
+// Keep the capture clock independent from requestAnimationFrame throttling in
+// headless environments; the page itself still stops its progress bar at 56s.
+await page.waitForTimeout(56_500);
+await context.close();
+await browser.close();
+server.close();
+
+const recorded = await page.video().path();
+const ffmpeg = process.env.FFMPEG || "ffmpeg";
+const encoded = spawnSync(ffmpeg, [
+  "-y", "-i", recorded,
+  "-c:v", "libx264", "-preset", "medium", "-crf", "20",
+  "-pix_fmt", "yuv420p", "-movflags", "+faststart", mp4,
+], { stdio: "inherit" });
+if (encoded.status !== 0) process.exit(encoded.status || 1);
+if (recorded !== webm) {
+  try { rmSync(recorded, { force: true }); } catch { /* the MP4 is the deliverable */ }
+}
+console.log(`Wrote ${mp4}`);

--- a/engraphis/service.py
+++ b/engraphis/service.py
@@ -5041,10 +5041,69 @@ class MemoryService:
             selected_layers = {layer.value for layer in selected_graph_layers}
         # Nodes are capped at ``limit``; edges need their own cap or a large workspace
         # graph / indexed repo lets the lowest-privilege caller pull an unbounded
-        # payload (the SQL fetches are LIMIT-ed too, so server-side work stays
-        # bounded as well — entity edges sync from peers, so they are as attacker-
-        # growable as code edges).
+        # payload. The SQL fetches are limited too, so server-side work stays bounded.
         edge_cap = max(limit * 8, 2000)
+        # A workspace can legitimately have an A-MEM graph before it has extracted
+        # entities: direct memory links are first-class relationships, not merely an
+        # implementation detail of the code overlay.  The old dashboard endpoint
+        # returned an empty graph in that case even though the complete Galaxy scene
+        # could already render the linked memories.  Surface the bounded, live subset
+        # here as a useful fallback for both Graph-tab clients.
+        memory_link_fallback: list[dict] = []
+        if not entity_rows and selected_graph_layers != []:
+            now = time.time()
+            sql = (
+                "SELECT link.a, link.b, link.relation, "
+                "COALESCE(link.layer, 'semantic') AS layer, "
+                "COALESCE(link.reason, '') AS reason, "
+                "COALESCE(NULLIF(left_memory.title, ''), "
+                "substr(left_memory.content, 1, 80)) AS a_name, "
+                "left_memory.mtype AS a_mtype, "
+                "COALESCE(NULLIF(right_memory.title, ''), "
+                "substr(right_memory.content, 1, 80)) AS b_name, "
+                "right_memory.mtype AS b_mtype "
+                "FROM mem_links link "
+                "JOIN memories left_memory ON left_memory.id=link.a "
+                "JOIN memories right_memory ON right_memory.id=link.b "
+                "WHERE left_memory.workspace_id=? AND right_memory.workspace_id=? "
+                "AND COALESCE(left_memory.scope, 'workspace')!='session' "
+                "AND COALESCE(right_memory.scope, 'workspace')!='session' "
+                "AND (left_memory.valid_from IS NULL OR left_memory.valid_from<=?) "
+                "AND (left_memory.valid_to IS NULL OR ?<left_memory.valid_to) "
+                "AND left_memory.expired_at IS NULL "
+                "AND (right_memory.valid_from IS NULL OR right_memory.valid_from<=?) "
+                "AND (right_memory.valid_to IS NULL OR ?<right_memory.valid_to) "
+                "AND right_memory.expired_at IS NULL "
+            )
+            params: list[Any] = [wid, wid, now, now, now, now]
+            if selected_graph_layers:
+                marks = ",".join("?" for _ in selected_graph_layers)
+                sql += f"AND COALESCE(link.layer, 'semantic') IN ({marks}) "
+                params.extend(layer.value for layer in selected_graph_layers)
+            sql += "ORDER BY link.created_at, link.rowid LIMIT ?"
+            params.append(edge_cap)
+
+            fallback_nodes: dict[str, dict] = {}
+            for row in conn.execute(sql, params).fetchall():
+                link = dict(row)
+                new_ids = {link["a"], link["b"]} - fallback_nodes.keys()
+                if len(fallback_nodes) + len(new_ids) > limit:
+                    continue
+                for prefix, memory_id in (("a", link["a"]), ("b", link["b"])):
+                    fallback_nodes.setdefault(memory_id, {
+                        "id": memory_id,
+                        "name": (
+                            link[f"{prefix}_name"]
+                            or memory_id
+                        ),
+                        "etype": f"memory_{link[f'{prefix}_mtype']}",
+                    })
+                memory_link_fallback.append({
+                    "a": link["a"], "b": link["b"],
+                    "relation": link["relation"], "layer": link["layer"],
+                    "reason": link["reason"],
+                })
+            entity_rows = list(fallback_nodes.values())
         visible_edge_ids = None
         if restrict_sessions:
             visible_edge_ids = {
@@ -5073,6 +5132,15 @@ class MemoryService:
                 or (edge.layer.value if edge.layer else "semantic") in selected_layers
             )
         ]
+        for link in memory_link_fallback:
+            if len(edgs) >= edge_cap:
+                break
+            edgs.append({
+                "src": link["a"], "dst": link["b"],
+                "relation": link["relation"],
+                "layer": link.get("layer") or "semantic",
+                "reason": link.get("reason") or "",
+            })
         repo_names: list[str] = []
         if include_code:
             repo_rows = []

--- a/engraphis/static/dashboard.js
+++ b/engraphis/static/dashboard.js
@@ -443,16 +443,16 @@ function renderSync(d){const el=document.getElementById('sync-body');if(!el)retu
 async function syncNow(){const b=document.getElementById('sync-btn');const s=document.getElementById('sync-status');if(b){b.disabled=true;b.textContent='Syncing…'}if(s)s.textContent='Contacting the cloud…';try{const d=await api('/sync/run',{method:'POST',headers:{'Content-Type':'application/json'},body:'{}'});const su=d.summary||{};toast('Synced — pushed '+(su.exported||0)+', '+(su.added||0)+' new from other devices','ok');await loadSyncStatus()}catch(e){toast('Sync failed: '+e.message,'err');if(b){b.disabled=false;b.textContent='Sync now'}if(s)s.textContent='Sync failed — try again.'}}
 
 /* ─── knowledge graph (force-graph + d3-force: compact defaults and selectable layouts) ─── */
-let GRAPH=null, FG=null, GRESIZE=false, GRESIZEFRAME=0, GADJ={}, GCOMPONENTS={}, GCOMPONENT_LAYOUT=null, GHILITE=null, GHOVERSET=null, GLABELRANK={}, GLABELBOXES=[], GDATA_CACHE=null, GACTIVE_DATA=null, GREDRAWFRAME=0, GPERF={large:false,dense:false};
+let GRAPH=null, FG=null, GRESIZE=false, GRESIZEFRAME=0, GADJ={}, GCOMM_ADJ={}, GCOMPONENTS={}, GCOMPONENT_LAYOUT=null, GHILITE=null, GHOVERSET=null, GLABELRANK={}, GLABELBOXES=[], GDATA_CACHE=null, GACTIVE_DATA=null, GREDRAWFRAME=0, GPERF={large:false,dense:false};
 const GRAPH_PRESETS={
  original:{label:'Original force',repel:120,link:30,gravity:14,font:13,size:3,linkw:1,labelDensity:40,curve:0,particles:0},
  compact:{label:'Compact clusters',repel:42,link:20,gravity:26,font:12,size:3,linkw:.7,labelDensity:30,curve:.08,particles:0},
- communities:{label:'Community islands',repel:58,link:22,gravity:26,font:13,size:3,linkw:.8,labelDensity:50,curve:.16,particles:0},
+ communities:{label:'Community islands',repel:48,link:16,gravity:48,font:12,size:3,linkw:.72,labelDensity:24,curve:.12,particles:0},
  radial:{label:'Radial orbit',repel:68,link:26,gravity:12,font:13,size:3,linkw:.75,labelDensity:55,curve:.22,particles:0},
  constellation:{label:'Constellation flow',repel:34,link:16,gravity:38,font:12,size:3,linkw:.65,labelDensity:35,curve:.32,particles:2},
  custom:{label:'Custom tuning',curve:.1,particles:0}
 };
-window.GSET=window.GSET||{mode:'compact',font:12,size:3,repel:42,link:20,gravity:26,labels:false,linkw:.7,labelDensity:30,flow:true,frozen:false};
+window.GSET=window.GSET||{mode:'communities',font:12,size:3,repel:48,link:16,gravity:48,labels:false,linkw:.72,labelDensity:24,flow:true,frozen:false};
 const ETYPE_TOKEN={person_or_concept:'--entity-concept',mention:'--entity-mention',hashtag:'--entity-hashtag',email:'--entity-email',organization:'--entity-organization',location:'--entity-location'};
 const GRAPH_PALETTES={
  theme:null,
@@ -538,7 +538,7 @@ async function loadLegacyGraph(){
  }
  const layerInputs=Array.from(document.querySelectorAll('#graph-layer-filters input')),selectedLayers=layerInputs.filter(input=>input.checked).map(input=>input.value),layerFilter=selectedLayers.length===layerInputs.length?'':'&layers='+encodeURIComponent(selectedLayers.join(',')),includeCode=document.getElementById('graph-include-code').checked,repo=(document.getElementById('graph-repo-filter').value||'').trim();
  try{
-  GRAPH=await api('/graph?workspace='+encodeURIComponent(WS||'')+layerFilter+'&include_code='+(includeCode?'true':'false')+(repo?'&repo='+encodeURIComponent(repo):''));
+   GRAPH=await api('/graph?workspace='+encodeURIComponent(WS||'')+layerFilter+'&include_code='+(includeCode?'true':'false')+(repo?'&repo='+encodeURIComponent(repo):''));
   renderGraphSide();graphRender();
  }catch(error){
   showAs(empty,true,'flex');empty.textContent='Graph failed: '+error.message;graphSetLayoutStatus('Load failed',false);
@@ -562,7 +562,19 @@ function graphData(){
  const links=GRAPH.edges.filter(edge=>names.has(edge.from)&&names.has(edge.to)).map(edge=>({source:edge.from,target:edge.to,label:edge.label,layer:edge.layer||'semantic'}));
  const data={nodes,links};GDATA_CACHE={graph:GRAPH,hideIso,data};return data;
 }
-function buildAdj(links){GADJ={};links.forEach(link=>{const source=(link.source&&link.source.id)||link.source,target=(link.target&&link.target.id)||link.target;(GADJ[source]=GADJ[source]||new Set()).add(target);(GADJ[target]=GADJ[target]||new Set()).add(source)})}
+function buildAdj(links){
+ GADJ={};GCOMM_ADJ={};
+ links.forEach(link=>{
+  const source=(link.source&&link.source.id)||link.source,target=(link.target&&link.target.id)||link.target;
+  (GADJ[source]=GADJ[source]||new Set()).add(target);(GADJ[target]=GADJ[target]||new Set()).add(source);
+  GCOMM_ADJ[source]=GCOMM_ADJ[source]||new Set();GCOMM_ADJ[target]=GCOMM_ADJ[target]||new Set();
+  // Influence links often connect otherwise distinct bodies of work. Keep them
+  // visible, but do not let a few such bridges collapse all communities into one.
+  if(link.label!=='influences'){
+   (GCOMM_ADJ[source]=GCOMM_ADJ[source]||new Set()).add(target);(GCOMM_ADJ[target]=GCOMM_ADJ[target]||new Set()).add(source);
+  }
+ });
+}
 function graphIndexComponents(nodes){
  const seen=new Set(),components=[];
  nodes.forEach(node=>{
@@ -580,10 +592,22 @@ function graphIndexComponents(nodes){
   ids.forEach(id=>{GCOMPONENTS[id]={index,size:ids.length,x,y}});
  });
 }
+function graphIndexCommunities(nodes){
+ const groups={};
+ nodes.forEach(node=>{const key=Number.isFinite(node.community)?node.community:0;(groups[key]=groups[key]||[]).push(node);});
+ const communities=Object.entries(groups).sort((a,b)=>b[1].length-a[1].length);
+ const cols=Math.max(1,Math.ceil(Math.sqrt(communities.length))),gap=Math.max(150,window.GSET.link*9);
+ GCOMPONENTS={};
+ communities.forEach(([key,members],index)=>{
+  const row=Math.floor(index/cols),col=index%cols,used=Math.min(cols,communities.length-row*cols);
+  const x=(col-(used-1)/2)*gap,y=(row-(Math.ceil(communities.length/cols)-1)/2)*gap;
+  members.forEach(node=>{GCOMPONENTS[node.id]={index,size:members.length,x,y,community:Number(key)};});
+ });
+}
 function graphRefreshComponentCenters(nodes,force=false){
  const layout=window.GSET.mode+'|'+window.GSET.link;
  if(!force&&GCOMPONENT_LAYOUT===layout)return;
- graphIndexComponents(nodes);GCOMPONENT_LAYOUT=layout;
+ if(window.GSET.mode==='communities')graphIndexCommunities(nodes);else graphIndexComponents(nodes);GCOMPONENT_LAYOUT=layout;
 }
 function graphAlpha(color,alpha){
  const hex=/^#([0-9a-f]{6})$/i.exec(color||'');
@@ -670,22 +694,18 @@ var GCOLORBY='community';try{var _cb=localStorage.getItem('engraphis-graph-color
 var GMAXDEG=1;
 function graphCommunityPalette(){return COMMUNITY_PALS[(typeof GSTYLE!=='undefined'&&COMMUNITY_PALS[GSTYLE])?GSTYLE:'classic'];}
 function graphComputeCommunities(nodes){
- var label={},ids=[];nodes.forEach(function(n,i){label[n.id]=i;ids.push(n.id);});
- for(var iter=0;iter<7;iter++){
-  var changed=false;
-  for(var a=ids.length-1;a>0;a--){var b=Math.floor(Math.random()*(a+1));var t=ids[a];ids[a]=ids[b];ids[b]=t;}
-  for(var j=0;j<ids.length;j++){
-   var id=ids[j],nb=GADJ[id];if(!nb||!nb.size)continue;
-   var counts={},best=label[id],bestC=-1;
-   nb.forEach(function(x){var l=label[x];counts[l]=(counts[l]||0)+1;if(counts[l]>bestC||(counts[l]===bestC&&l<best)){bestC=counts[l];best=l;}});
-   if(label[id]!==best){label[id]=best;changed=true;}
+ var byId={},seen=new Set(),groups=[];nodes.forEach(function(node){byId[node.id]=node;});
+ nodes.forEach(function(node){
+  if(seen.has(node.id))return;
+  var group=[],stack=[node.id];seen.add(node.id);
+  while(stack.length){
+   var id=stack.pop();group.push(id);var neighbours=GCOMM_ADJ[id]||new Set();
+   neighbours.forEach(function(next){if(byId[next]&&!seen.has(next)){seen.add(next);stack.push(next);}});
   }
-  if(!changed)break;
- }
- var groups={};nodes.forEach(function(n){var l=label[n.id];(groups[l]=groups[l]||[]).push(n);});
- var order=Object.keys(groups).sort(function(x,y){return groups[y].length-groups[x].length;});
- var remap={};order.forEach(function(l,i){remap[l]=i;});
- nodes.forEach(function(n){n.community=remap[label[n.id]];});
+  groups.push(group);
+ });
+ groups.sort(function(a,b){return b.length-a.length;});
+ groups.forEach(function(group,index){group.forEach(function(id){byId[id].community=index;});});
 }
 function graphHeatColor(node){var total=(GACTIVE_DATA&&GACTIVE_DATA.nodes.length)||1;var t=(node.rank||0)/Math.max(1,total-1);var idx=Math.min(GRAPH_HEAT.length-1,Math.floor(t*GRAPH_HEAT.length));return GRAPH_HEAT[idx];}
 function graphNodeColor(node){
@@ -821,9 +841,11 @@ function graphRender(fit=true,reheat=true){
  FG.nodePointerAreaPaint((node,color,ctx)=>{const radius=Math.max(3,node.radius)+3;ctx.beginPath();ctx.arc(node.x,node.y,radius,0,2*Math.PI);ctx.fillStyle=color;ctx.fill()});
  FG.linkColor(link=>{
   const focus=GHOVERSET&&GHOVERSET.size>1,source=(link.source&&link.source.id)||link.source,target=(link.target&&link.target.id)||link.target,active=!focus||source===GHILITE||target===GHILITE;
-  const palette=window.GCOL.links[link.layer]||window.GCOL.links.semantic;return active?(focus?palette.active:palette.base):palette.dim;
+  const palette=window.GCOL.links[link.layer]||window.GCOL.links.semantic;
+  if(link.label==='influences')return active?graphAlpha(window.GCOL.layers[link.layer]||window.GCOL.layers.semantic,focus?.34:.18):palette.dim;
+  return active?(focus?palette.active:palette.base):palette.dim;
  });
- FG.linkWidth(link=>{const width=window.GSET.linkw||1,focus=GHOVERSET&&GHOVERSET.size>1;if(!focus)return (GPERF.dense?.62:.82)*width;const source=(link.source&&link.source.id)||link.source,target=(link.target&&link.target.id)||link.target;return (source===GHILITE||target===GHILITE)?1.8*width:.25*width});
+ FG.linkWidth(link=>{const width=window.GSET.linkw||1,focus=GHOVERSET&&GHOVERSET.size>1,bridge=link.label==='influences';if(!focus)return (bridge?.45:(GPERF.dense?.62:.82))*width;const source=(link.source&&link.source.id)||link.source,target=(link.target&&link.target.id)||link.target;return (source===GHILITE||target===GHILITE)?(bridge?1.0:1.8)*width:.25*width});
  if(FG.linkLineDash)FG.linkLineDash(GPERF.dense?null:(link=>link.layer==='temporal'?[4,3]:(link.layer==='causal'?[2,2]:null)));
  if(FG.linkCurvature)FG.linkCurvature(GPERF.dense?0:mode.curve);
  FG.linkDirectionalArrowLength(GPERF.dense?0:2.5).linkDirectionalArrowRelPos(1);
@@ -892,7 +914,7 @@ function graphApplyPreset(name){
  const notes={
   original:'Original force graph · stronger repulsion and weak centering reproduce the previous, wider spacing.',
   compact:'Compact clusters · shorter links, gentler repulsion and stronger centering keep connected memories together.',
-  communities:'Community islands · connected components are packed around nearby component centers.',
+  communities:'Community islands · detected communities have their own gravity centers, while sparse bridges remain visible.',
   radial:'Radial orbit · high-degree entities settle near the center while lower-degree entities form outer rings.',
   constellation:'Constellation flow · curved directional relationships for smaller graphs.',
   custom:'Custom tuning · the appearance and physics controls below define this view.'

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -11,10 +11,11 @@ module.exports = defineConfig({
     screenshot: 'only-on-failure',
   },
   webServer: {
-    command: 'engraphis-dashboard --no-open --port 8700',
+    // Run the checked-out source, not a possibly stale globally installed console script.
+    command: 'python -m scripts.start_dashboard --no-open --port 8700',
     url: 'http://127.0.0.1:8700/api/health',
     timeout: 120_000,
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: false,
     env: {
       ENGRAPHIS_EMBED_MODEL: '',
       ENGRAPHIS_LOOP_INTERVAL: '0',
@@ -29,4 +30,3 @@ module.exports = defineConfig({
     },
   ],
 });
-

--- a/tests/test_service_graph.py
+++ b/tests/test_service_graph.py
@@ -311,6 +311,102 @@ def test_graph_lazy_backfills_preexisting_memories():
     assert "Alice Johnson" in labels and "Acme Corp" in labels
 
 
+def test_graph_falls_back_to_direct_memory_links_without_entities():
+    """A-MEM links form a useful graph even when entity extraction is disabled."""
+    svc = MemoryService.create(":memory:", graph_extractor="none")
+    first = svc.remember("Synthetic alpha", workspace="acme", scope="workspace")
+    second = svc.remember("Synthetic beta", workspace="acme", scope="workspace")
+    svc.link(first["id"], second["id"], workspace="acme", relation="causes")
+
+    graph = svc.graph(workspace="acme")
+    assert {node["id"] for node in graph["nodes"]} == {first["id"], second["id"]}
+    assert {row["etype"] for row in graph["types"]} == {"memory_semantic"}
+    assert {
+        "from": first["id"], "to": second["id"],
+        "label": "causes", "layer": "causal",
+    } in graph["edges"]
+
+
+def test_graph_memory_link_fallback_excludes_session_scope():
+    """The workspace graph must never surface private session memories."""
+    svc = MemoryService.create(":memory:", graph_extractor="none")
+    session = svc.start_session("acme", repo="r", agent="codex", goal="private")
+    private_a = svc.remember(
+        "Private alpha", workspace="acme", repo="r",
+        session_id=session["session_id"], scope="session",
+    )
+    private_b = svc.remember(
+        "Private beta", workspace="acme", repo="r",
+        session_id=session["session_id"], scope="session",
+    )
+    svc.link(private_a["id"], private_b["id"], workspace="acme", relation="causes")
+
+    assert svc.graph(workspace="acme")["nodes"] == []
+
+
+def test_graph_memory_link_fallback_respects_empty_layer_filter():
+    svc = MemoryService.create(":memory:", graph_extractor="none")
+    first = svc.remember("Synthetic alpha", workspace="acme", scope="workspace")
+    second = svc.remember("Synthetic beta", workspace="acme", scope="workspace")
+    svc.link(first["id"], second["id"], workspace="acme", relation="causes")
+
+    graph = svc.graph(workspace="acme", layers=[])
+    assert graph["nodes"] == []
+    assert graph["edges"] == []
+
+
+def test_graph_memory_link_fallback_samples_links_before_unrelated_memories():
+    """A small graph limit must still select connected memories."""
+    svc = MemoryService.create(":memory:", graph_extractor="none")
+    svc.engine.auto_evolve = False
+    for index in range(5):
+        svc.remember(
+            f"Unlinked memory {index}", workspace="acme", scope="workspace"
+        )
+    first = svc.remember(
+        "Orchid deployment requires manual approval.",
+        workspace="acme", scope="workspace",
+    )
+    second = svc.remember(
+        "Jupiter telemetry is retained for thirty days.",
+        workspace="acme", scope="workspace",
+    )
+    svc.link(first["id"], second["id"], workspace="acme", relation="causes")
+
+    graph = svc.graph(workspace="acme", limit=2)
+
+    assert {node["id"] for node in graph["nodes"]} == {first["id"], second["id"]}
+    assert graph["edges"] == [{
+        "from": first["id"], "to": second["id"],
+        "label": "causes", "layer": "causal",
+    }]
+
+
+def test_graph_memory_link_fallback_projects_bounded_content_excerpts():
+    """Fallback SQL must not materialize full memory bodies just to label nodes."""
+    svc = MemoryService.create(":memory:", graph_extractor="none")
+    svc.engine.auto_evolve = False
+    first = svc.remember("A" * 100_000, workspace="acme", scope="workspace")
+    second = svc.remember("B" * 100_000, workspace="acme", scope="workspace")
+    svc.link(first["id"], second["id"], workspace="acme", relation="causes")
+    statements = []
+    svc.store.conn.set_trace_callback(statements.append)
+
+    try:
+        graph = svc.graph(workspace="acme", limit=2)
+    finally:
+        svc.store.conn.set_trace_callback(None)
+
+    assert {node["label"] for node in graph["nodes"]} == {"A" * 80, "B" * 80}
+    fallback_queries = [sql for sql in statements if "FROM mem_links link" in sql]
+    assert len(fallback_queries) == 1
+    projection = fallback_queries[0].lower()
+    assert "substr(left_memory.content, 1, 80)" in projection
+    assert "substr(right_memory.content, 1, 80)" in projection
+    assert "left_memory.content as" not in projection
+    assert "right_memory.content as" not in projection
+
+
 def test_graph_lazy_backfill_is_idempotent():
     """Re-opening the Graph tab must not duplicate entities."""
     svc = MemoryService.create(":memory:", graph_extractor="regex")


### PR DESCRIPTION
## Summary
- add a privacy-safe direct-memory-link fallback for entity-free A-MEM graphs, with bounded SQL projections and regression coverage
- make community-island layout deterministic while keeping cross-community influence bridges visible and preserving the complete graph explorer dataset
- add a reproducible local screen-demo source and recorder while gitignoring all generated payloads, frames, WebM files, and the final MP4
- make Playwright launch the checked-out dashboard instead of a stale globally installed entry point

## Local verification
- `python -m pytest tests/ -q`
- `ruff check .`
- `npx playwright test` (4 passed)
- `node --check engraphis/static/dashboard.js`
- `node --check demo/record_screen_demo.mjs`
- sample and CodeMem retrieval evals: recall@5, hit@5, token recall all 1.0
- ablation: base vector/1-hop/PPR 1.0; multi-hop PPR 1.0
- package build and `twine check dist/*`
- 57.08-second 1920x1080 H.264 demo recording generated and visually sampled locally; output remains ignored

## Merge gate
Local Docker is unavailable, so merge is gated on both normal PR CI and a non-publishing manual `release.yml` run for this branch. That workflow performs the clean dependency audit, Python matrix, browser checks, package checks, and production Docker health smoke. No tag or package publication is requested by this PR.