### PR TITLE
Make Stripe the launch billing authority

### DIFF
--- a/engraphis/commercial.py
+++ b/engraphis/commercial.py
@@ -10,12 +10,7 @@ import json
 from pathlib import Path
 
 
-PRODUCT_ENV = {
-    "POLAR_PRO_MONTHLY_PRODUCT_ID": ("pro", "monthly"),
-    "POLAR_PRO_ANNUAL_PRODUCT_ID": ("pro", "annual"),
-    "POLAR_TEAM_MONTHLY_PRODUCT_ID": ("team", "monthly"),
-    "POLAR_TEAM_ANNUAL_PRODUCT_ID": ("team", "annual"),
-}
+BILLING_AUTHORITY = "stripe"
 
 
 def manifest() -> dict:
@@ -24,13 +19,14 @@ def manifest() -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def expected_product_ids() -> dict:
-    """Return the manifest's public product identifiers keyed by environment name."""
+def expected_checkout_targets() -> dict:
+    """Return public onboarding targets without exposing provider-side price identifiers."""
     expected = {}
     for plan_name in ("pro", "team"):
         for interval, product in manifest()["plans"][plan_name]["products"].items():
-            expected[product["env"]] = {
-                "id": product["id"],
+            expected[(plan_name, interval)] = {
+                "provider": product["provider"],
+                "checkout_url": product["checkout_url"],
                 "plan": plan_name,
                 "interval": interval,
             }

--- a/engraphis/commercial_manifest.json
+++ b/engraphis/commercial_manifest.json
@@ -1,8 +1,16 @@
 {
-  "schema": "engraphis-commercial/v1",
+  "schema": "engraphis-commercial/v2",
   "version": "1.0.0",
   "control_plane": "https://api.engraphis.com",
   "managed_dashboard": "https://team.engraphis.com",
+  "billing": {
+    "authority": "stripe",
+    "new_subscriptions": "stripe",
+    "legacy_providers": [],
+    "checkout_mode": "authenticated_server_session",
+    "portal_url": "https://api.engraphis.com/account#billing",
+    "provider_price_ids_public": false
+  },
   "trial": {
     "days": 3,
     "card_required": false,
@@ -43,14 +51,12 @@
       "billing_unit": "installation",
       "products": {
         "monthly": {
-          "id": "6349d29a-b4c0-4b8e-b9e8-071705351c9c",
-          "env": "POLAR_PRO_MONTHLY_PRODUCT_ID",
-          "checkout_url": "https://buy.polar.sh/polar_cl_n6CR3ERqOus2VUhRrGrsRUqOB8yjDTeEU7p1r3CRrae?product_id=6349d29a-b4c0-4b8e-b9e8-071705351c9c"
+          "provider": "stripe",
+          "checkout_url": "https://api.engraphis.com/account?plan=pro&interval=monthly#billing"
         },
         "annual": {
-          "id": "5e10d5d2-607a-4e9c-ad1c-88cb48c37e11",
-          "env": "POLAR_PRO_ANNUAL_PRODUCT_ID",
-          "checkout_url": "https://buy.polar.sh/polar_cl_n6CR3ERqOus2VUhRrGrsRUqOB8yjDTeEU7p1r3CRrae?product_id=5e10d5d2-607a-4e9c-ad1c-88cb48c37e11"
+          "provider": "stripe",
+          "checkout_url": "https://api.engraphis.com/account?plan=pro&interval=annual#billing"
         }
       }
     },
@@ -60,14 +66,12 @@
       "billing_unit": "seat",
       "products": {
         "monthly": {
-          "id": "6444a48a-7a61-4c8e-8045-07a930f8f381",
-          "env": "POLAR_TEAM_MONTHLY_PRODUCT_ID",
-          "checkout_url": "https://buy.polar.sh/polar_cl_n6CR3ERqOus2VUhRrGrsRUqOB8yjDTeEU7p1r3CRrae?product_id=6444a48a-7a61-4c8e-8045-07a930f8f381"
+          "provider": "stripe",
+          "checkout_url": "https://api.engraphis.com/account?plan=team&interval=monthly#billing"
         },
         "annual": {
-          "id": "929d926a-2981-4ad7-95bd-f52dabf0794e",
-          "env": "POLAR_TEAM_ANNUAL_PRODUCT_ID",
-          "checkout_url": "https://buy.polar.sh/polar_cl_n6CR3ERqOus2VUhRrGrsRUqOB8yjDTeEU7p1r3CRrae?product_id=929d926a-2981-4ad7-95bd-f52dabf0794e"
+          "provider": "stripe",
+          "checkout_url": "https://api.engraphis.com/account?plan=team&interval=annual#billing"
         }
       }
     }

--- a/scripts/check_commercial_manifest.py
+++ b/scripts/check_commercial_manifest.py
@@ -4,22 +4,23 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import sys
 from pathlib import Path
 from urllib.parse import parse_qs, urlsplit
 
 
 ROOT = Path(__file__).resolve().parents[1]
 MANIFEST_PATH = ROOT / "engraphis" / "commercial_manifest.json"
+sys.path.insert(0, str(ROOT))
 
 
 def _fail(errors: list[str], message: str) -> None:
     errors.append(message)
 
 
-def _product_mapping(manifest: dict, errors: list[str]) -> dict:
-    """Validate billing identities and return env -> (plan, interval)."""
+def _checkout_mapping(manifest: dict, errors: list[str]) -> dict:
+    """Validate server-owned checkout targets and return (plan, interval) -> URL."""
     mapping = {}
-    ids = set()
     checkout_urls = set()
     plans = manifest.get("plans") if isinstance(manifest, dict) else None
     if not isinstance(plans, dict):
@@ -36,42 +37,55 @@ def _product_mapping(manifest: dict, errors: list[str]) -> dict:
             if not isinstance(product, dict):
                 _fail(errors, "%s %s product must be an object" % (plan, interval))
                 continue
-            product_id = product.get("id")
-            env_name = product.get("env")
+            if set(product) != {"provider", "checkout_url"}:
+                _fail(
+                    errors,
+                    "%s %s product exposes unsupported provider data" % (plan, interval),
+                )
+                continue
+            if product.get("provider") != "stripe":
+                _fail(errors, "%s %s product is not controlled by Stripe" % (plan, interval))
+                continue
             checkout_url = product.get("checkout_url")
-            if not isinstance(product_id, str) or not re.fullmatch(
-                    r"[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}", product_id):
-                _fail(errors, "%s %s product id is not a canonical UUID" % (plan, interval))
-                continue
-            if product_id in ids:
-                _fail(errors, "Polar product id is duplicated: %s" % product_id)
-            ids.add(product_id)
-            if not isinstance(env_name, str) or not re.fullmatch(r"POLAR_[A-Z_]+_PRODUCT_ID",
-                                                                  env_name):
-                _fail(errors, "%s %s product env is invalid" % (plan, interval))
-                continue
-            if env_name in mapping:
-                _fail(errors, "Polar product environment is duplicated: %s" % env_name)
-            mapping[env_name] = (plan, interval)
             if not isinstance(checkout_url, str):
                 _fail(errors, "%s %s checkout URL is missing" % (plan, interval))
                 continue
             parsed = urlsplit(checkout_url)
             query = parse_qs(parsed.query)
-            if parsed.scheme != "https" or parsed.netloc != "buy.polar.sh" \
-                    or query.get("product_id") != [product_id]:
-                _fail(errors, "%s %s checkout URL does not match its product id" % (
-                    plan, interval))
+            if (
+                parsed.scheme != "https"
+                or parsed.netloc != "api.engraphis.com"
+                or parsed.path != "/account"
+                or parsed.fragment != "billing"
+                or query != {"plan": [plan], "interval": [interval]}
+            ):
+                _fail(
+                    errors,
+                    "%s %s checkout URL is not the canonical account portal" % (plan, interval),
+                )
+                continue
             if checkout_url in checkout_urls:
-                _fail(errors, "Polar checkout URL is duplicated: %s" % checkout_url)
+                _fail(errors, "checkout URL is duplicated: %s" % checkout_url)
             checkout_urls.add(checkout_url)
+            mapping[(plan, interval)] = checkout_url
     return mapping
 
 
 def _check_repository(manifest: dict, errors: list[str]) -> None:
-    if manifest.get("schema") != "engraphis-commercial/v1":
-        _fail(errors, "commercial manifest schema must be engraphis-commercial/v1")
-    mapping = _product_mapping(manifest, errors)
+    if manifest.get("schema") != "engraphis-commercial/v2":
+        _fail(errors, "commercial manifest schema must be engraphis-commercial/v2")
+    mapping = _checkout_mapping(manifest, errors)
+    expected_billing = {
+        "authority": "stripe",
+        "new_subscriptions": "stripe",
+        "legacy_providers": [],
+        "checkout_mode": "authenticated_server_session",
+        "portal_url": "https://api.engraphis.com/account#billing",
+        "provider_price_ids_public": False,
+    }
+    if manifest.get("billing") != expected_billing:
+        _fail(errors, "Stripe must be the sole launch billing authority")
+
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
     match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject, re.MULTILINE)
     if not match or match.group(1) != manifest["version"]:
@@ -87,8 +101,9 @@ def _check_repository(manifest: dict, errors: list[str]) -> None:
     if re.search(r"img\.shields\.io/badge/version-[^\s)]+", readme):
         _fail(errors, "README must not advertise an unpublished hard-coded version badge")
 
-    template = json.loads((ROOT / "deploy" / "railway-template.json").read_text(
-        encoding="utf-8"))
+    template = json.loads(
+        (ROOT / "deploy" / "railway-template.json").read_text(encoding="utf-8")
+    )
     service = template.get("service", {})
     variables = template.get("variables", {})
     if service.get("healthcheck") != "/api/ready":
@@ -103,30 +118,40 @@ def _check_repository(manifest: dict, errors: list[str]) -> None:
         if variables.get(name, {}).get("value") != expected:
             _fail(errors, "Railway variable %s does not match manifest" % name)
     local_api = variables.get("ENGRAPHIS_API_TOKEN", {})
-    if not local_api.get("required") or not local_api.get("secret") \
-            or local_api.get("value") != "${{ secret(48) }}":
+    if (
+        not local_api.get("required")
+        or not local_api.get("secret")
+        or local_api.get("value") != "${{ secret(48) }}"
+    ):
         _fail(errors, "Railway template must generate a secret local API token")
 
-    from engraphis.commercial import PRODUCT_ENV, expected_product_ids
-    expected = expected_product_ids()
-    if mapping != PRODUCT_ENV:
-        _fail(errors, "Polar product environment mapping drifted from manifest")
+    from engraphis.commercial import BILLING_AUTHORITY, expected_checkout_targets
+
+    expected = expected_checkout_targets()
+    if BILLING_AUTHORITY != "stripe":
+        _fail(errors, "public billing authority drifted from Stripe")
     if set(expected) != set(mapping) or any(
-            expected[env].get("id") != manifest["plans"][plan]["products"][interval]["id"]
-            for env, (plan, interval) in mapping.items() if env in expected):
-        _fail(errors, "commercial product catalog parser drifted from manifest")
+        expected[key].get("provider") != "stripe"
+        or expected[key].get("checkout_url") != checkout_url
+        for key, checkout_url in mapping.items()
+        if key in expected
+    ):
+        _fail(errors, "commercial checkout catalog parser drifted from manifest")
 
 
 def _check_website(manifest: dict, website: Path, errors: list[str]) -> None:
-    files = [website / name for name in ("index.html", "product.html", "about.html",
-                                          "contact.html")]
+    files = [
+        website / name
+        for name in ("index.html", "product.html", "about.html", "contact.html")
+    ]
     missing = [str(path) for path in files if not path.is_file()]
     if missing:
         _fail(errors, "website files missing: " + ", ".join(missing))
         return
     website_manifest = website / "commercial_manifest.json"
-    if (not website_manifest.is_file()
-            or json.loads(website_manifest.read_text(encoding="utf-8")) != manifest):
+    if not website_manifest.is_file() or (
+        json.loads(website_manifest.read_text(encoding="utf-8")) != manifest
+    ):
         _fail(errors, "website commercial manifest copy differs from canonical manifest")
     text = "\n".join(path.read_text(encoding="utf-8") for path in files)
     public_text = "\n".join(
@@ -134,12 +159,17 @@ def _check_website(manifest: dict, website: Path, errors: list[str]) -> None:
     )
     lower = public_text.lower()
     for unsupported in (
-            "end-to-end encrypted", "no phone-home", "sso/rbac",
-            "it never leaves your machine"):
+        "end-to-end encrypted",
+        "no phone-home",
+        "sso/rbac",
+        "it never leaves your machine",
+    ):
         if unsupported in lower:
             _fail(errors, "website advertises unsupported claim: %s" % unsupported)
     if re.search(r"\bsla\b", public_text, re.IGNORECASE):
         _fail(errors, "website advertises unsupported claim: SLA")
+    if "polar" in lower:
+        _fail(errors, "website advertises Polar as a launch billing authority")
     required = [
         "v" + manifest["version"],
         "%d-day" % manifest["trial"]["days"],
@@ -150,12 +180,9 @@ def _check_website(manifest: dict, website: Path, errors: list[str]) -> None:
         if claim not in text:
             _fail(errors, "website is missing manifest claim: %s" % claim)
     for plan in ("pro", "team"):
-        for product in manifest["plans"][plan]["products"].values():
+        for interval, product in manifest["plans"][plan]["products"].items():
             if product["checkout_url"] not in text:
-                _fail(errors, "website is missing %s checkout %s" % (
-                    plan, product["id"]))
-    if re.search(r'href="[^"]*polar[^"]*"[^>]*>[^<]*trial', text, re.IGNORECASE):
-        _fail(errors, "trial links must use deployment onboarding, not Polar")
+                _fail(errors, "website is missing %s %s checkout" % (plan, interval))
 
 
 def main() -> int:

--- a/scripts/init.py
+++ b/scripts/init.py
@@ -196,9 +196,8 @@ def main(argv=None) -> int:
     print("\nNext steps:")
     print("  engraphis-dashboard      # product UI on http://127.0.0.1:8700")
     print("  engraphis-init --check   # verify the install")
-    print("  Free forever at the core - 3-day free trial for Pro (in the dashboard: "
-          "Settings -> License), or buy at "
-          "https://buy.polar.sh/polar_cl_n6CR3ERqOus2VUhRrGrsRUqOB8yjDTeEU7p1r3CRrae")
+    print("  Free forever at the core - start the 3-day Pro trial or subscribe at "
+          "https://api.engraphis.com/account?plan=pro&interval=monthly#billing")
     return 0
 
 

--- a/tests/test_licensing_boundary_docs.py
+++ b/tests/test_licensing_boundary_docs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from engraphis.commercial import BILLING_AUTHORITY, expected_checkout_targets
 from engraphis.hosted_client import TRIAL_DAYS
 
 
@@ -52,6 +53,28 @@ def test_manifest_keeps_trial_and_grace_as_separate_clocks():
         "relicensing",
     } <= set(lifecycle["recovery"]["allows"])
 
+
+def test_manifest_uses_stripe_as_the_only_launch_billing_authority():
+    manifest = json.loads(_text("engraphis/commercial_manifest.json"))
+    billing = manifest["billing"]
+    targets = expected_checkout_targets()
+
+    assert BILLING_AUTHORITY == billing["authority"] == billing["new_subscriptions"] == "stripe"
+    assert billing["legacy_providers"] == []
+    assert billing["checkout_mode"] == "authenticated_server_session"
+    assert billing["provider_price_ids_public"] is False
+    assert set(targets) == {
+        ("pro", "monthly"),
+        ("pro", "annual"),
+        ("team", "monthly"),
+        ("team", "annual"),
+    }
+    for (plan, interval), target in targets.items():
+        assert target["provider"] == "stripe"
+        assert target["checkout_url"] == (
+            f"https://api.engraphis.com/account?plan={plan}&interval={interval}#billing"
+        )
+    assert "polar" not in json.dumps(manifest).lower()
 
 def test_public_docs_state_the_license_and_lapse_boundaries():
     readme = _text("README.md")


### PR DESCRIPTION
## What changed

- moves the public commercial manifest to `engraphis-commercial/v2`
- declares Stripe as the only authority for new subscriptions
- removes public Polar product IDs, environment names, and direct checkout links
- routes Pro and Team monthly/annual onboarding through the authenticated private `/account` portal
- updates initialization guidance and release checks so provider-side Stripe Price IDs remain private

## Why

The public manifest still directed customers to Polar while the private control plane implements Stripe webhooks and self-service Stripe Checkout/Portal. That allowed two providers to appear authoritative for the same organization and exposed provider catalog identifiers in the public contract.

## Impact

New subscriptions have one public entry point and one provider authority. Polar is not advertised as a legacy authority because migration and reconciliation are not yet implemented. This PR does not tag or publish v1.0.0.

## Validation

- `python -m pytest tests/ -q`
- `python -m eval.harness --dataset eval/datasets/sample.jsonl --k 5`
- `python -m eval.harness --dataset eval/datasets/codemem.jsonl --k 5`
- `python -m eval.ablation`
- `ruff check .`
- `python scripts/check_commercial_manifest.py`
- `git diff --check`