### PR TITLE
Release Engraphis v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,10 +54,9 @@ All notable changes to Engraphis are documented here. Format loosely follows
 - Graph GET requests are strictly read-only. While an explicit mutating index job runs, graph
   reads return a rebuilding conflict instead of mixing old and partially derived metrics.
 
-## [1.0.0] - Unreleased
+## [1.0.0] - 2026-07-23
 
-Release candidate for the public 1.0.0 open-core GA. Replace `Unreleased` with the actual
-publication date only in the final authorized release commit.
+Public 1.0.0 open-core GA release.
 
 ### Added
 

--- a/tests/test_release_infrastructure.py
+++ b/tests/test_release_infrastructure.py
@@ -168,9 +168,9 @@ def test_public_capability_and_support_docs_match_the_shipped_tree():
 
     changelog = _text("CHANGELOG.md")
     assert "ForceGraph + D3 renderer" in changelog
-    assert "## [1.0.0] - Unreleased" in changelog
+    assert "## [1.0.0] - 2026-07-23" in changelog
     assert "## [1.0.0] - 2026-07-19" not in changelog
-    assert "Release candidate for the public 1.0.0 open-core GA" in changelog
+    assert "Public 1.0.0 open-core GA release." in changelog
 
     public_paths = [
         ROOT / name for name in (


### PR DESCRIPTION
Dates the reviewed 1.0.0 GA changelog and updates the release-infrastructure assertion. Full public suite, retrieval evaluations, ablation, lint, and wheel/sdist build were run from this clean worktree.