### PR TITLE
Select canonical tag artifacts for release repair

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,13 +298,13 @@ jobs:
             --branch "$RELEASE_TAG" \
             --event push \
             --limit 20 \
-            --json databaseId,headBranch,headSha,event)"
+            --json databaseId,headBranch,headSha,event,createdAt)"
           run_id="$(jq -r \
             --arg tag "$RELEASE_TAG" \
             --arg sha "$tag_sha" \
-            'map(select(.headBranch == $tag and
-                        .headSha == $sha and
-                        .event == "push"))[0].databaseId // empty' \
+            'sort_by(.createdAt) | map(select(.headBranch == $tag and
+                                            .headSha == $sha and
+                                            .event == "push"))[0].databaseId // empty' \
             <<<"$runs")"
           test -n "$run_id"
           jobs="$(gh run view "$run_id" --repo "$GH_REPO" --json jobs)"

--- a/tests/test_release_infrastructure.py
+++ b/tests/test_release_infrastructure.py
@@ -108,10 +108,11 @@ def test_release_repair_requires_tag_sha_successful_build_publish_and_pypi_ident
     assert '"repos/${GH_REPO}/git/ref/tags/${RELEASE_TAG}"' in repair
     assert '"repos/${GH_REPO}/git/tags/${tag_sha}"' in repair
     assert 'test "$object_type" = "commit"' in repair
-    assert "--json databaseId,headBranch,headSha,event" in repair
+    assert "--json databaseId,headBranch,headSha,event,createdAt" in repair
     assert ".headBranch == $tag" in repair
     assert ".headSha == $sha" in repair
     assert '.event == "push"' in repair
+    assert "sort_by(.createdAt)" in repair
     assert '.name == "Build distributions"' in repair
     assert '.name == "Publish to PyPI"' in repair
     assert '.name == "Assemble distributions"' not in repair


### PR DESCRIPTION
Repair reruns now choose the earliest tag-push run for the immutable tag commit. The current PyPI v1.0.0 hashes match that original run; a later identical-tag push produced non-reproducible build artifacts and must not be used for GitHub Release repair.