### PR TITLE
docs: describe Cloud early access onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ All notable changes to Engraphis are documented here. Format loosely follows
 
 ### Changed
 
+- Documentation now describes the official Railway-hosted Cloud as limited early access with
+  manual onboarding, without representing a self-service paid lifecycle as generally available.
 - The legacy graph view now defaults to deterministic community islands, keeps sparse
   influence bridges visually subordinate, and renders bounded direct A-MEM links even when
   entity extraction is disabled. A reproducible repository-local screen-demo workflow exercises

--- a/README.md
+++ b/README.md
@@ -193,6 +193,13 @@ outside code that a fork controls.
 - **Team** adds hosted organizations, invitations, named seats, roles, scoped credentials, and
   organization audit. Devices do not consume seats.
 
+### Railway-hosted Cloud early access
+
+The official Railway-hosted Cloud is currently offered as limited early access. Pro and Team
+onboarding is manual: [request access](https://engraphis.com/contact), then configuration and
+activation are arranged with each customer. Availability is limited; these plan descriptions do
+not promise immediate self-service checkout or activation.
+
 The no-card trial starts only after email confirmation and lasts **exactly 3 active days**.
 See [Licensing](docs/LICENSING.md), [Cloud Sync](docs/SYNC.md), and
 [Agent Connect](docs/AGENT_CONNECT.md). The public image can still be deployed as a free local

--- a/docs/HOSTING_RAILWAY.md
+++ b/docs/HOSTING_RAILWAY.md
@@ -8,6 +8,13 @@ A public deployment is therefore a remote **free customer node**, not a self-hos
 backend. Premium status/CTA surfaces connect authorized customers to the official private cloud.
 No service-mode or environment switch adds the missing server implementations.
 
+## Official Cloud early access
+
+The official Railway-hosted Cloud is offered as limited early access. Pro and Team onboarding is
+manual: [request access](https://engraphis.com/contact), then customer configuration and
+activation are arranged individually. This customer-runtime guide cannot provision a hosted
+account, and it does not promise immediate self-service checkout or activation.
+
 ## Deploy
 
 Use the `Dockerfile`, mount a private persistent volume at `/data`, and configure:


### PR DESCRIPTION
## What changed

Documents the Railway-hosted Cloud as limited early access with manual Pro and Team onboarding.

## Why

The existing Railway core is suitable for a small, known cohort, while self-service paid activation and enterprise operations have not yet been exercised as a general-availability service.

## Impact

Customers get an accurate path to request access without an unsupported promise of immediate checkout or activation. Local free use remains unchanged.

## Validation

- `pytest -q tests/test_licensing_boundary_docs.py`
- Commercial manifest check
- `git diff --check`