### PR TITLE
fix(tests): keep the offline gate hermetic for model-fallback tests

### DIFF
--- a/tests/test_backends_factories.py
+++ b/tests/test_backends_factories.py
@@ -8,30 +8,33 @@ from engraphis.backends.vector_sqlitevec import get_vector_index
 from engraphis.core.store import Store
 
 
-def _force_unresolvable(monkeypatch, attr: str) -> None:
-    """Make the sentence-transformers loader fail immediately instead of hitting the network.
+def _force_load_failure(monkeypatch, module, attr: str) -> None:
+    """Make the heavy model adapter fail at construction, without touching the network.
 
     The factories fall back when a model fails to load, but resolving an unknown model name
     normally goes out to the Hugging Face Hub. On a host with no route to the Hub that
     connect() blocks rather than erroring, so the offline gate would hang forever — the
-    fallback relies on the network failing *fast*, not on it being *absent* (AGENTS.md §3.8:
-    the core must run offline). Patching the loader keeps this hermetic and instant.
-    """
-    try:
-        import sentence_transformers as st
-    except ImportError:
-        return  # not installed — the factory already fails fast with ModuleNotFoundError
+    fallback relies on the network failing *fast*, not on it being *absent* (AGENTS.md §3:
+    the core must run offline).
 
+    Patch the adapter the factory constructs, not sentence-transformers itself: the optional
+    heavy stack is then never imported here, so an install that raises something other than
+    ImportError (e.g. a RuntimeError from a mismatched torch) cannot fail this test. Every
+    such failure stays inside the factory, which catches Exception and falls back — which is
+    exactly the contract under test.
+    """
     def _raise(*args, **kwargs):
         raise OSError("simulated unresolvable model (offline)")
 
-    monkeypatch.setattr(st, attr, _raise)
+    monkeypatch.setattr(module, attr, _raise)
 
 
 def test_embedder_factory_falls_back_offline(monkeypatch):
+    import engraphis.backends.embedder_st as embedder_st
+
     assert isinstance(get_embedder(None, 128), DeterministicEmbedder)
     # An unresolvable model name must not crash — it falls back.
-    _force_unresolvable(monkeypatch, "SentenceTransformer")
+    _force_load_failure(monkeypatch, embedder_st, "SentenceTransformerEmbedder")
     assert isinstance(get_embedder("definitely-not-a-real-model-xyz", 128), DeterministicEmbedder)
 
 
@@ -68,6 +71,8 @@ def test_vector_index_factory_modes(monkeypatch):
 
 
 def test_reranker_factory_falls_back_offline(monkeypatch):
+    import engraphis.backends.reranker as reranker
+
     assert isinstance(get_reranker(None), IdentityReranker)
-    _force_unresolvable(monkeypatch, "CrossEncoder")
+    _force_load_failure(monkeypatch, reranker, "CrossEncoderReranker")
     assert isinstance(get_reranker("definitely-not-a-real-model-xyz"), IdentityReranker)

--- a/tests/test_backends_factories.py
+++ b/tests/test_backends_factories.py
@@ -8,9 +8,30 @@ from engraphis.backends.vector_sqlitevec import get_vector_index
 from engraphis.core.store import Store
 
 
-def test_embedder_factory_falls_back_offline():
+def _force_unresolvable(monkeypatch, attr: str) -> None:
+    """Make the sentence-transformers loader fail immediately instead of hitting the network.
+
+    The factories fall back when a model fails to load, but resolving an unknown model name
+    normally goes out to the Hugging Face Hub. On a host with no route to the Hub that
+    connect() blocks rather than erroring, so the offline gate would hang forever — the
+    fallback relies on the network failing *fast*, not on it being *absent* (AGENTS.md §3.8:
+    the core must run offline). Patching the loader keeps this hermetic and instant.
+    """
+    try:
+        import sentence_transformers as st
+    except ImportError:
+        return  # not installed — the factory already fails fast with ModuleNotFoundError
+
+    def _raise(*args, **kwargs):
+        raise OSError("simulated unresolvable model (offline)")
+
+    monkeypatch.setattr(st, attr, _raise)
+
+
+def test_embedder_factory_falls_back_offline(monkeypatch):
     assert isinstance(get_embedder(None, 128), DeterministicEmbedder)
     # An unresolvable model name must not crash — it falls back.
+    _force_unresolvable(monkeypatch, "SentenceTransformer")
     assert isinstance(get_embedder("definitely-not-a-real-model-xyz", 128), DeterministicEmbedder)
 
 
@@ -46,6 +67,7 @@ def test_vector_index_factory_modes(monkeypatch):
     s.close()
 
 
-def test_reranker_factory_falls_back_offline():
+def test_reranker_factory_falls_back_offline(monkeypatch):
     assert isinstance(get_reranker(None), IdentityReranker)
+    _force_unresolvable(monkeypatch, "CrossEncoder")
     assert isinstance(get_reranker("definitely-not-a-real-model-xyz"), IdentityReranker)


### PR DESCRIPTION
## Problem

`python -m pytest tests/ -q` — the offline gate documented in `CLAUDE.md` and `AGENTS.md` §1 — **hangs indefinitely on a host with no network route**, rather than passing or failing.

Two tests assert that the backend factories fall back when a model cannot be loaded:

- `test_embedder_factory_falls_back_offline`
- `test_reranker_factory_falls_back_offline`

Both pass an unresolvable model name, which sends `SentenceTransformer` / `CrossEncoder` to the Hugging Face Hub to resolve it. When the host has **no route** to the Hub, the TCP connect sits in `SynSent` instead of erroring, so the suite never reaches a summary line.

The fallback relied on the network failing **fast**, not on it being **absent** — which is precisely the condition AGENTS.md §3 ("local-first and offline-capable") requires the core to survive.

## Fix

Patch the sentence-transformers loader in both tests so the load failure is raised locally and instantly. No network is touched, and the fallback contract each test exists to verify is still exercised end-to-end through `get_embedder` / `get_reranker`.

If `sentence_transformers` is not installed at all, the helper no-ops — the factory already fails fast with `ModuleNotFoundError`, which is the path minimal CI (`pip install numpy pytest`) takes.

Test-only change. No production code is modified.

## Verification

Full offline gate, run locally:

- `python -m pytest tests/ -q` — completes; previously hung forever
- `python -m ruff check .` — All checks passed
- `python -m eval.harness --dataset eval/datasets/sample.jsonl --k 5` — recall@k 1.000, hit@k 1.000, answer_token_recall 1.000
- `python -m eval.harness --dataset eval/datasets/codemem.jsonl --k 5` — recall@k 1.000, hit@k 1.000, answer_token_recall 1.000
- `python -m eval.ablation` — vector-only 1.0, hybrid-1hop 1.0, hybrid-ppr 1.0; multi-hop arm-level: vector 0.667, graph 1-hop 0.0, graph PPR 1.0

The two target tests now complete in well under a second with `--timeout=30`.

## Note on an unrelated pre-existing failure

`tests/test_session_idempotent.py::test_session_close_linearizes_before_delayed_memory_write[ingest]` fails locally when a developer `.env` sets `ENGRAPHIS_EXTRACTOR=llm` with an unreachable provider: the LLM client retries 2s + 4s and exceeds the test's 10s budget. It reproduces standalone on `main` without this branch, and CI has no `.env`, so it is green there. Not addressed here — it is the same hermeticity gap in a different place and deserves its own change (neutralising LLM env vars in `tests/conftest.py`).
