### PR TITLE
test(licensing): make the outage-is-not-a-cancellation test actually test that

### DIFF
--- a/tests/test_hosted_plan_resolution.py
+++ b/tests/test_hosted_plan_resolution.py
@@ -941,8 +941,13 @@ def test_a_transport_failure_is_not_mistaken_for_a_billing_denial(monkeypatch) -
     assert _settled_license(monkeypatch)["cloud_access_active"] is True
 
     def _offline(*_args, **_kwargs):
+        # ``CloudSessionError`` takes only ``status``; ``transient`` belongs to
+        # ``CloudFeatureError``. Passing it here raised TypeError instead, which the
+        # caller's broad ``except Exception`` swallowed with no ``status`` attribute -- so
+        # this test used to pass by never exercising a 503 at all, and would not have
+        # caught a regression that let a genuine outage clear a paying customer's access.
         raise cloud_session.CloudSessionError(
-            "Engraphis Cloud is temporarily unreachable.", status=503, transient=True
+            "Engraphis Cloud is temporarily unreachable.", status=503
         )
 
     monkeypatch.setattr(cloud_session, "access_for_workspace", _offline)


### PR DESCRIPTION
## The defect

`test_a_transport_failure_is_not_mistaken_for_a_billing_denial` raised:

```python
cloud_session.CloudSessionError("...", status=503, transient=True)
```

`CloudSessionError.__init__` accepts only `message` and `status` — **`transient` belongs to `CloudFeatureError`**. So the construction raised `TypeError`, `_fetch_authoritative_entitlement`'s broad `except Exception` swallowed it, and `getattr(exc, "status", None)` returned `None` instead of `503`.

The assertion passed while **never exercising a transport failure at all**. It was proving "a `TypeError` doesn't revoke access" — not "a 503 doesn't".

This is mine: I introduced it earlier in this session while adding the 402 billing-denial handling.

## Why it matters

That test guards a revenue-visible behaviour: only a `402` may clear a paying customer's cached access; an outage must not. The gate is:

```python
if getattr(exc, "status", None) == 402:
    record_billing_denial()
    _deny_entitlement_cache()
```

If that were ever loosened to `if getattr(exc, "status", None):`, a 503 would revoke a paying customer mid-outage. The test existed to catch exactly that — and could not, because `TypeError` carries no `status` attribute at all, so the mutation was invisible to it.

## Verification

Mutation-tested both ways:

- **Gate loosened to any-truthy-status, after this fix** → test **fails**: `AssertionError: an outage revoked a paying customer`, with `cloud_access_active: False`.
- Same mutation, before this fix → test **passed**.

Full offline gate on this branch: **1,397 passed / 0 failed** (1,411 collected, 14 skipped), `ruff check .` clean.

One-line change plus a comment recording why, so the conflation is not reintroduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)