### PR TITLE
Harden hosted session and portal routing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,11 +61,10 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=300s --retries=3 \
 # running the CMD (or any Railway/compose start-command override, which becomes its args).
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
-# Default: the v2 team dashboard (multi-user auth, roles, seats, cloud-license clients,
-# Pro sync clients) — this is what docker-compose.yml already defaults to, and what
-# every hosted deployment (e.g. Railway) needs, since it's the only entrypoint that
-# serves /api/auth/*, /api/license/*, and /api/bootstrap. `--no-open`: never try to launch
-# a browser in a container.
+# Default: the v2 local customer dashboard with hosted-service clients. Team identity, roles,
+# seats, and organization management are hosted at the authenticated account portal, not this
+# public image. This entrypoint serves /api/auth/*, /api/license/*, and /api/bootstrap.
+# `--no-open`: never try to launch a browser in a container.
 #
 # The raw v1 single-user API server is still available — run `engraphis-server` directly
 # (see docker-compose.yml's opt-in "api" profile) — but it shares this image's exposed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
-# Default `docker compose up` runs the TEAM-capable dashboard (multi-user auth, roles,
-# seats, license revocation, Pro sync) — the thing teams actually deploy. The raw
-# single-user v1 API server is available under the "api" profile after setting a strong
+# Default `docker compose up` runs the local customer dashboard and its hosted-service clients.
+# Team identity, roles, seats, and organization management remain in the private account portal.
+# The raw single-user v1 API server is available under the "api" profile after setting a strong
 # ENGRAPHIS_API_TOKEN in .env or the shell:
 #     docker compose --profile api up engraphis-api
 #
@@ -13,7 +13,7 @@ services:
   engraphis:
     build: .
     image: engraphis:latest
-    # Team dashboard on the v2 engine. --no-open: never try to launch a browser in a
+    # Local customer dashboard on the v2 engine. --no-open: never try to launch a browser in a
     # container. Binds 0.0.0.0 via the ENGRAPHIS_HOST below (explicit here; the image
     # itself no longer bakes a host — its entrypoint defaults to `::` dual-stack).
     command: ["engraphis-dashboard", "--no-open"]

--- a/docs/AGENT_CONNECT.md
+++ b/docs/AGENT_CONNECT.md
@@ -25,9 +25,9 @@ organization:
 
 1. The organization owner starts Team or purchases a subscription in Engraphis Cloud.
 2. The owner invites named members and assigns roles in the hosted dashboard.
-3. A member accepts the invitation and generates a one-time **connect token** (`engr_ct_…`).
-   The account portal shows the exact command to run.
-4. The member runs that command on the machine being connected (see below).
+3. An organization owner or admin generates a one-time **connect token** (`engr_ct_…`) for
+   their own connected machine. The account portal shows the exact command to run.
+4. That owner or admin runs the command on the machine being connected (see below).
 5. The hosted service rechecks organization membership, role, scopes, entitlement version, and
    workspace binding on every request.
 

--- a/engraphis/cloud_session.py
+++ b/engraphis/cloud_session.py
@@ -102,7 +102,7 @@ def _validated_token_subject(value: object) -> str:
     return subject
 
 
-def _token_subject(saved: dict) -> str:
+def _token_subject(saved: dict, *, uses_persisted_credential: bool = True) -> str:
     """Return the immutable subject bound to the current credential family.
 
     ``ENGRAPHIS_CLOUD_TOKEN_SUBJECT`` selects the subject for an environment-only
@@ -111,11 +111,13 @@ def _token_subject(saved: dict) -> str:
     environment override win causes the next refresh to present (for example) a
     member credential as ``device``; the service must reject that mismatch, and the
     client then has to retire a credential that was never actually spent.  Persisted
-    state therefore wins whenever it carries a subject.
+    state therefore wins only while the selected credential itself is persisted.
+    A retired saved credential leaves its subject behind for auditability; a replacement
+    environment bootstrap credential must instead use its explicitly configured subject.
     """
 
     persisted = saved.get("token_subject")
-    if persisted is not None and str(persisted).strip():
+    if uses_persisted_credential and persisted is not None and str(persisted).strip():
         return _validated_token_subject(persisted)
     configured = os.environ.get("ENGRAPHIS_CLOUD_TOKEN_SUBJECT", "").strip()
     return _validated_token_subject(configured or "member")
@@ -794,15 +796,15 @@ def configured(*, require_compute: bool = True) -> bool:
     # A configured environment value is bootstrap material. After its first successful
     # use, the server-returned rotation is persisted and must take precedence; otherwise
     # every subsequent call would replay the now-invalid bootstrap credential.
-    refresh = str(saved.get("refresh_credential") or "").strip()
-    refresh = refresh or os.environ.get("ENGRAPHIS_CLOUD_REFRESH_CREDENTIAL", "").strip()
+    saved_refresh = str(saved.get("refresh_credential") or "").strip()
+    refresh = saved_refresh or os.environ.get("ENGRAPHIS_CLOUD_REFRESH_CREDENTIAL", "").strip()
     if _refresh_is_unusable(saved, refresh):
         refresh = ""
     control = os.environ.get("ENGRAPHIS_CLOUD_CONTROL_URL", "").strip()
     control = control or str(saved.get("control_url") or "").strip()
     compute = direct_compute or str(saved.get("compute_url") or "").strip()
     if refresh and control:
-        _token_subject(saved)
+        _token_subject(saved, uses_persisted_credential=bool(saved_refresh))
     return bool(refresh and control and (compute or not require_compute))
 
 
@@ -837,8 +839,8 @@ def access_for_workspace(
         # single-use credential; reading it before the lock lets two workers spend the
         # same value and causes one request to fail as a replay.
         saved = _load()
-        refresh = str(saved.get("refresh_credential") or "").strip()
-        refresh = refresh or os.environ.get(
+        saved_refresh = str(saved.get("refresh_credential") or "").strip()
+        refresh = saved_refresh or os.environ.get(
             "ENGRAPHIS_CLOUD_REFRESH_CREDENTIAL", ""
         ).strip()
         if _refresh_is_unusable(saved, refresh):
@@ -856,7 +858,9 @@ def access_for_workspace(
             )
         control = _reachable_cloud_base_url(control)
         compute = _reachable_cloud_base_url(compute) if compute else ""
-        token_subject = _token_subject(saved)
+        token_subject = _token_subject(
+            saved, uses_persisted_credential=bool(saved_refresh)
+        )
         try:
             body = _post_refresh(control, refresh, workspace_id, token_subject)
         except CloudSessionError as exc:

--- a/engraphis/cloud_session.py
+++ b/engraphis/cloud_session.py
@@ -103,8 +103,22 @@ def _validated_token_subject(value: object) -> str:
 
 
 def _token_subject(saved: dict) -> str:
+    """Return the immutable subject bound to the current credential family.
+
+    ``ENGRAPHIS_CLOUD_TOKEN_SUBJECT`` selects the subject for an environment-only
+    bootstrap credential.  Once a successful bootstrap has persisted a credential,
+    its subject is part of that credential's server-side contract.  Letting a later
+    environment override win causes the next refresh to present (for example) a
+    member credential as ``device``; the service must reject that mismatch, and the
+    client then has to retire a credential that was never actually spent.  Persisted
+    state therefore wins whenever it carries a subject.
+    """
+
+    persisted = saved.get("token_subject")
+    if persisted is not None and str(persisted).strip():
+        return _validated_token_subject(persisted)
     configured = os.environ.get("ENGRAPHIS_CLOUD_TOKEN_SUBJECT", "").strip()
-    return _validated_token_subject(configured or saved.get("token_subject") or "member")
+    return _validated_token_subject(configured or "member")
 
 
 def _reachable_cloud_base_url(value: str) -> str:

--- a/engraphis/commercial_manifest.json
+++ b/engraphis/commercial_manifest.json
@@ -2,7 +2,7 @@
   "schema": "engraphis-commercial/v2",
   "version": "1.1.5",
   "control_plane": "https://api.engraphis.com",
-  "managed_dashboard": "https://team.engraphis.com",
+  "account_portal": "https://api.engraphis.com/account",
   "billing": {
     "authority": "stripe",
     "new_subscriptions": "stripe",

--- a/engraphis/config.py
+++ b/engraphis/config.py
@@ -458,8 +458,8 @@ def _configured_db_path(root: Path = _PROJECT_ROOT) -> str:
     return str(target)
 
 
-#: Vendor-hosted managed sync service. The account dashboard remains at
-#: ``team.engraphis.com``; sync traffic goes to its separate relay endpoint.
+#: Vendor-hosted managed sync service. The authenticated account portal is at
+#: ``https://api.engraphis.com/account``; sync traffic goes to this separate relay endpoint.
 DEFAULT_RELAY_URL = "https://relay.engraphis.com"
 
 SERVICE_MODES = ("customer",)

--- a/engraphis/hosted_client.py
+++ b/engraphis/hosted_client.py
@@ -111,11 +111,32 @@ def _safe_target(value: str) -> str:
     text = str(value or "").strip()
     if not text:
         return ""
+    # urlsplit normalizes some ASCII controls while parsing.  Returning the original
+    # operator string after that would still put those controls in dashboard metadata
+    # and customer-facing hrefs, so reject them before parsing instead of relying on a
+    # browser-side sanitizer to repair server output.
+    if any(ord(char) < 32 or ord(char) == 127 for char in text):
+        return ""
     try:
         parts = urlsplit(text)
     except ValueError:
         return ""
-    if not parts.hostname:
+    if (
+        not parts.hostname
+        # Upgrade/account destinations are rendered as links, not credential-bearing
+        # transport endpoints.  Userinfo in an operator override would make browsers
+        # send that credential to the destination on click (and can expose it in the
+        # address bar or browser history), so it is never a safe hosted destination.
+        or parts.username is not None
+        or parts.password is not None
+    ):
+        return ""
+    try:
+        # Accessing ``port`` is validation: urlsplit accepts an invalid textual port
+        # until this property is read.  Do not hand a dead/malformed URL to the
+        # dashboard and call it a valid upgrade destination.
+        parts.port
+    except ValueError:
         return ""
     if parts.scheme == "https":
         return text

--- a/scripts/check_commercial_manifest.py
+++ b/scripts/check_commercial_manifest.py
@@ -74,6 +74,10 @@ def _checkout_mapping(manifest: dict, errors: list[str]) -> dict:
 def _check_repository(manifest: dict, errors: list[str]) -> None:
     if manifest.get("schema") != "engraphis-commercial/v2":
         _fail(errors, "commercial manifest schema must be engraphis-commercial/v2")
+    if manifest.get("account_portal") != "https://api.engraphis.com/account":
+        _fail(errors, "account portal must be the canonical authenticated control-plane URL")
+    if "managed_dashboard" in manifest:
+        _fail(errors, "commercial manifest must not advertise a separate managed dashboard")
     mapping = _checkout_mapping(manifest, errors)
     expected_units = {"free": "installation", "pro": "owner", "team": "seat"}
     for plan, expected_unit in expected_units.items():

--- a/tests/test_cloud_session.py
+++ b/tests/test_cloud_session.py
@@ -195,10 +195,12 @@ def test_replaced_environment_bootstrap_is_not_blocked_by_a_spent_predecessor(
 
     monkeypatch.setenv("ENGRAPHIS_CLOUD_REFRESH_CREDENTIAL", "replacement-bootstrap")
     monkeypatch.setenv("ENGRAPHIS_CLOUD_CONTROL_URL", "https://control.example.test")
+    monkeypatch.setenv("ENGRAPHIS_CLOUD_TOKEN_SUBJECT", "device")
     state = {
         "refresh_unusable": True,
         "refresh_unusable_at": 1.0,
         "refresh_unusable_digest": cloud_session._refresh_digest("spent-bootstrap"),
+        "token_subject": "member",
     }
     requests = []
     monkeypatch.setattr(cloud_session, "_load", lambda: dict(state))
@@ -210,18 +212,19 @@ def test_replaced_environment_bootstrap_is_not_blocked_by_a_spent_predecessor(
     )
 
     def refresh(control_url, credential, workspace_id, token_subject):
-        requests.append(credential)
+        requests.append((credential, token_subject))
         return {
             "access_token": "replacement-access",
             "organization_id": "org_1",
             "refresh_credential": "rotated-replacement",
-            "token_subject": "member",
+            "token_subject": "device",
         }
 
     monkeypatch.setattr(cloud_session, "_post_refresh", refresh)
     assert cloud_session.configured(require_compute=False) is True
     assert cloud_session.access_for_workspace("ws", require_compute=False)[0] == "replacement-access"
-    assert requests == ["replacement-bootstrap"]
+    assert requests == [("replacement-bootstrap", "device")]
+    assert state["token_subject"] == "device"
     assert "refresh_unusable" not in state
     assert "refresh_unusable_digest" not in state
 

--- a/tests/test_cloud_session.py
+++ b/tests/test_cloud_session.py
@@ -110,6 +110,15 @@ def test_environment_refresh_honors_explicit_device_subject(monkeypatch) -> None
     assert writes[0]["refresh_credential"] == "rotated-but-env-owned"
 
 
+def test_persisted_refresh_subject_cannot_be_overridden_by_environment(monkeypatch) -> None:
+    """A bootstrap-only setting must not invalidate an already-bound credential."""
+
+    monkeypatch.setenv("ENGRAPHIS_CLOUD_TOKEN_SUBJECT", "device")
+    saved = {"token_subject": "member", "refresh_credential": "engr_rt_saved"}
+
+    assert cloud_session._token_subject(saved) == "member"
+
+
 def test_environment_bootstrap_persists_and_reuses_rotated_credential(monkeypatch) -> None:
     monkeypatch.setenv("ENGRAPHIS_CLOUD_REFRESH_CREDENTIAL", "env-bootstrap")
     monkeypatch.setenv("ENGRAPHIS_CLOUD_CONTROL_URL", "https://control.example.test")

--- a/tests/test_hosted_client.py
+++ b/tests/test_hosted_client.py
@@ -38,6 +38,23 @@ def test_upgrade_urls_are_hosted_metadata_only(monkeypatch):
     assert hosted_client.required_plan("team") == "team"
 
 
+@pytest.mark.parametrize("value", [
+    "https://operator:secret@billing.example.test/account",
+    "https://billing.example.test:not-a-port/account",
+    "https://billing.example.test/\naccount",
+])
+def test_hosted_checkout_overrides_reject_userinfo_and_invalid_ports(monkeypatch, value):
+    """Never render a plan CTA that embeds credentials or cannot be opened safely."""
+
+    monkeypatch.setenv("ENGRAPHIS_PRO_UPGRADE_URL", value)
+    monkeypatch.setenv("ENGRAPHIS_UPGRADE_URL", value)
+
+    assert hosted_client.upgrade_url("pro") == (
+        "https://api.engraphis.com/account?plan=pro&interval=monthly#billing"
+    )
+    assert hosted_client.account_url() == "https://api.engraphis.com/account"
+
+
 def test_cloud_url_validation_requires_safe_remote_https(monkeypatch):
     monkeypatch.setattr(
         hosted_client.socket,

--- a/tests/test_licensing_boundary_docs.py
+++ b/tests/test_licensing_boundary_docs.py
@@ -65,6 +65,8 @@ def test_manifest_uses_stripe_as_the_only_launch_billing_authority():
     assert billing["legacy_providers"] == []
     assert billing["checkout_mode"] == "authenticated_server_session"
     assert billing["provider_price_ids_public"] is False
+    assert manifest["account_portal"] == "https://api.engraphis.com/account"
+    assert "managed_dashboard" not in manifest
     assert set(targets) == {
         ("pro", "monthly"),
         ("pro", "annual"),


### PR DESCRIPTION
## What changed\n- Preserve the persisted cloud credential subject across refreshes.\n- Reject malformed or credential-bearing hosted destinations.\n- Route hosted Team management to the authenticated account portal and align local-dashboard wording.\n\n## Why\nPrevents valid cloud sessions from being retired by a later environment override and removes stale hosted-management links.\n\n## Validation\n- Focused cloud-session, hosted-client, device-connect, plan, and licensing tests\n- Ruff and diff integrity checks