### PR TITLE
Fix Classic graph nodes to retain Ledger material detail

### DIFF
--- a/engraphis/classic_assets/dashboard.js
+++ b/engraphis/classic_assets/dashboard.js
@@ -957,14 +957,14 @@ function graphMaterialSprite(p,tier){
  var spriteCtx=canvas.getContext('2d');if(!spriteCtx)return null;if(typeof spriteCtx.scale==='function'){spriteCtx.scale(dpr,dpr);graphPaintMaterialDirect(spriteCtx,half,half,radius,p,tier)}else graphPaintMaterialDirect(spriteCtx,half*dpr,half*dpr,radius*dpr,p,tier);
  var value={canvas:canvas,half:half,radius:radius};GRAPH_MATERIAL_CACHE.set(key,value);if(GRAPH_MATERIAL_CACHE.size>GRAPH_MATERIAL_CACHE_LIMIT)GRAPH_MATERIAL_CACHE.delete(GRAPH_MATERIAL_CACHE.keys().next().value);return value;
 }
-function graphPaintMaterialSurface(ctx,x,y,r,scale,profile,large){
+function graphPaintMaterialSurface(ctx,x,y,r,scale,profile,large,paintDirect){
  var screenRadius=r*Math.max(.01,scale),tier=graphMaterialTier(screenRadius,large);
  /* A cached full sprite is 40 CSS pixels in radius. Enlarging it beyond that turns a focused
-    hub into the blocky blob reported in Classic. Paint that exceptional visible node directly:
-    it retains the exact same Ledger material recipe, while leaves and normal-sized nodes stay
-    on the bounded cache. This is paint-only; graph data, geometry, labels, and hit testing stay
-    untouched. */
- if(tier==='full'&&screenRadius>GRAPH_MATERIAL_RADIUS.full){graphPaintMaterialDirect(ctx,x,y,r,profile,tier);return tier}
+    hub into the blocky blob reported in Classic. Only the selected or top-ranked hub may paint
+    directly: a large zoom must not turn every leaf into per-frame gradient and brush work.
+    Every other node stays on the bounded cache. This is paint-only; graph data, geometry,
+    labels, and hit testing stay untouched. */
+ if(paintDirect&&tier==='full'&&screenRadius>GRAPH_MATERIAL_RADIUS.full){graphPaintMaterialDirect(ctx,x,y,r,profile,tier);return tier}
  var sprite=graphMaterialSprite(profile,tier);
  if(sprite&&typeof ctx.drawImage==='function'){var half=r*sprite.half/sprite.radius;ctx.drawImage(sprite.canvas,x-half,y-half,half*2,half*2)}else graphPaintMaterialDirect(ctx,x,y,r,profile,tier);
  return tier;
@@ -981,20 +981,20 @@ function graphStyleBackground(ctx,scale){
 function graphStyleNode(node,ctx,scale){
  if(!Number.isFinite(node.x)||!Number.isFinite(node.y))return;
  var focus=GHOVERSET&&GHOVERSET.size>1,neighbor=focus&&GHOVERSET.has(node.id),dim=focus&&!neighbor;
- var r=node.radius,col=node.color,profile;
+ var r=node.radius,col=node.color,profile,directMaterial=node.id===GHILITE||node.rank===0;
  ctx.globalAlpha=dim?.12:1;
  /* The sprite cache keeps material work bounded. Detail is therefore chosen only from this
     node's rendered size, just as in Ledger's overview; a large graph must not turn an
     on-screen hub into a flat signature disc solely because it has many distant leaves. */
  if(GSTYLE==='galaxy'){
-  profile=graphMaterialProfile('galaxy',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false);
+  profile=graphMaterialProfile('galaxy',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false,directMaterial);
  }else if(GSTYLE==='solar'){
   var sun=node.rank===0;if(sun)r*=1.7;
-  profile=graphMaterialProfile('solar',sun?graphMix(col,'#d38b43',.46):col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false);
+  profile=graphMaterialProfile('solar',sun?graphMix(col,'#d38b43',.46):col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false,directMaterial);
  }else if(GSTYLE==='cyber'){
-  profile=graphMaterialProfile('cyber',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false);
+  profile=graphMaterialProfile('cyber',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false,directMaterial);
  }else{
-  profile=graphMaterialProfile('classic',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false);
+  profile=graphMaterialProfile('classic',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false,directMaterial);
  }
  if(node.id===GHILITE){
   graphMaterialFill(ctx,node.x,node.y,r*.76,graphAlpha('#ffffff',.065));

--- a/engraphis/classic_assets/dashboard.js
+++ b/engraphis/classic_assets/dashboard.js
@@ -958,7 +958,14 @@ function graphMaterialSprite(p,tier){
  var value={canvas:canvas,half:half,radius:radius};GRAPH_MATERIAL_CACHE.set(key,value);if(GRAPH_MATERIAL_CACHE.size>GRAPH_MATERIAL_CACHE_LIMIT)GRAPH_MATERIAL_CACHE.delete(GRAPH_MATERIAL_CACHE.keys().next().value);return value;
 }
 function graphPaintMaterialSurface(ctx,x,y,r,scale,profile,large){
- var tier=graphMaterialTier(r*Math.max(.01,scale),large),sprite=graphMaterialSprite(profile,tier);
+ var screenRadius=r*Math.max(.01,scale),tier=graphMaterialTier(screenRadius,large);
+ /* A cached full sprite is 40 CSS pixels in radius. Enlarging it beyond that turns a focused
+    hub into the blocky blob reported in Classic. Paint that exceptional visible node directly:
+    it retains the exact same Ledger material recipe, while leaves and normal-sized nodes stay
+    on the bounded cache. This is paint-only; graph data, geometry, labels, and hit testing stay
+    untouched. */
+ if(tier==='full'&&screenRadius>GRAPH_MATERIAL_RADIUS.full){graphPaintMaterialDirect(ctx,x,y,r,profile,tier);return tier}
+ var sprite=graphMaterialSprite(profile,tier);
  if(sprite&&typeof ctx.drawImage==='function'){var half=r*sprite.half/sprite.radius;ctx.drawImage(sprite.canvas,x-half,y-half,half*2,half*2)}else graphPaintMaterialDirect(ctx,x,y,r,profile,tier);
  return tier;
 }
@@ -976,15 +983,18 @@ function graphStyleNode(node,ctx,scale){
  var focus=GHOVERSET&&GHOVERSET.size>1,neighbor=focus&&GHOVERSET.has(node.id),dim=focus&&!neighbor;
  var r=node.radius,col=node.color,profile;
  ctx.globalAlpha=dim?.12:1;
+ /* The sprite cache keeps material work bounded. Detail is therefore chosen only from this
+    node's rendered size, just as in Ledger's overview; a large graph must not turn an
+    on-screen hub into a flat signature disc solely because it has many distant leaves. */
  if(GSTYLE==='galaxy'){
-  profile=graphMaterialProfile('galaxy',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,GPERF.large);
+  profile=graphMaterialProfile('galaxy',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false);
  }else if(GSTYLE==='solar'){
   var sun=node.rank===0;if(sun)r*=1.7;
-  profile=graphMaterialProfile('solar',sun?graphMix(col,'#d38b43',.46):col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,GPERF.large);
+  profile=graphMaterialProfile('solar',sun?graphMix(col,'#d38b43',.46):col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false);
  }else if(GSTYLE==='cyber'){
-  profile=graphMaterialProfile('cyber',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,GPERF.large);
+  profile=graphMaterialProfile('cyber',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false);
  }else{
-  profile=graphMaterialProfile('classic',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,GPERF.large);
+  profile=graphMaterialProfile('classic',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false);
  }
  if(node.id===GHILITE){
   graphMaterialFill(ctx,node.x,node.y,r*.76,graphAlpha('#ffffff',.065));

--- a/engraphis/classic_assets/index.html
+++ b/engraphis/classic_assets/index.html
@@ -336,6 +336,6 @@
      graph view. dashboard.js fetches both on demand from graphRender(); see loadForceGraph()
      and loadGraphEngine(). scripts/externalize_dashboard_assets.py enforces both halves:
      they stay out of this file, and the lazy references still have to resolve. -->
-<script src="/classic-assets/dashboard.js?v=20260728-reference-materials"></script>
+<script src="/classic-assets/dashboard.js?v=20260728-crisp-node-materials"></script>
 </body>
 </html>

--- a/engraphis/classic_assets/index.html
+++ b/engraphis/classic_assets/index.html
@@ -336,6 +336,6 @@
      graph view. dashboard.js fetches both on demand from graphRender(); see loadForceGraph()
      and loadGraphEngine(). scripts/externalize_dashboard_assets.py enforces both halves:
      they stay out of this file, and the lazy references still have to resolve. -->
-<script src="/classic-assets/dashboard.js?v=20260728-crisp-node-materials"></script>
+<script src="/classic-assets/dashboard.js?v=20260729-hub-materials"></script>
 </body>
 </html>

--- a/engraphis/static/dashboard.js
+++ b/engraphis/static/dashboard.js
@@ -957,14 +957,14 @@ function graphMaterialSprite(p,tier){
  var spriteCtx=canvas.getContext('2d');if(!spriteCtx)return null;if(typeof spriteCtx.scale==='function'){spriteCtx.scale(dpr,dpr);graphPaintMaterialDirect(spriteCtx,half,half,radius,p,tier)}else graphPaintMaterialDirect(spriteCtx,half*dpr,half*dpr,radius*dpr,p,tier);
  var value={canvas:canvas,half:half,radius:radius};GRAPH_MATERIAL_CACHE.set(key,value);if(GRAPH_MATERIAL_CACHE.size>GRAPH_MATERIAL_CACHE_LIMIT)GRAPH_MATERIAL_CACHE.delete(GRAPH_MATERIAL_CACHE.keys().next().value);return value;
 }
-function graphPaintMaterialSurface(ctx,x,y,r,scale,profile,large){
+function graphPaintMaterialSurface(ctx,x,y,r,scale,profile,large,paintDirect){
  var screenRadius=r*Math.max(.01,scale),tier=graphMaterialTier(screenRadius,large);
  /* A cached full sprite is 40 CSS pixels in radius. Enlarging it beyond that turns a focused
-    hub into the blocky blob reported in Classic. Paint that exceptional visible node directly:
-    it retains the exact same Ledger material recipe, while leaves and normal-sized nodes stay
-    on the bounded cache. This is paint-only; graph data, geometry, labels, and hit testing stay
-    untouched. */
- if(tier==='full'&&screenRadius>GRAPH_MATERIAL_RADIUS.full){graphPaintMaterialDirect(ctx,x,y,r,profile,tier);return tier}
+    hub into the blocky blob reported in Classic. Only the selected or top-ranked hub may paint
+    directly: a large zoom must not turn every leaf into per-frame gradient and brush work.
+    Every other node stays on the bounded cache. This is paint-only; graph data, geometry,
+    labels, and hit testing stay untouched. */
+ if(paintDirect&&tier==='full'&&screenRadius>GRAPH_MATERIAL_RADIUS.full){graphPaintMaterialDirect(ctx,x,y,r,profile,tier);return tier}
  var sprite=graphMaterialSprite(profile,tier);
  if(sprite&&typeof ctx.drawImage==='function'){var half=r*sprite.half/sprite.radius;ctx.drawImage(sprite.canvas,x-half,y-half,half*2,half*2)}else graphPaintMaterialDirect(ctx,x,y,r,profile,tier);
  return tier;
@@ -981,20 +981,20 @@ function graphStyleBackground(ctx,scale){
 function graphStyleNode(node,ctx,scale){
  if(!Number.isFinite(node.x)||!Number.isFinite(node.y))return;
  var focus=GHOVERSET&&GHOVERSET.size>1,neighbor=focus&&GHOVERSET.has(node.id),dim=focus&&!neighbor;
- var r=node.radius,col=node.color,profile;
+ var r=node.radius,col=node.color,profile,directMaterial=node.id===GHILITE||node.rank===0;
  ctx.globalAlpha=dim?.12:1;
  /* The sprite cache keeps material work bounded. Detail is therefore chosen only from this
     node's rendered size, just as in Ledger's overview; a large graph must not turn an
     on-screen hub into a flat signature disc solely because it has many distant leaves. */
  if(GSTYLE==='galaxy'){
-  profile=graphMaterialProfile('galaxy',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false);
+  profile=graphMaterialProfile('galaxy',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false,directMaterial);
  }else if(GSTYLE==='solar'){
   var sun=node.rank===0;if(sun)r*=1.7;
-  profile=graphMaterialProfile('solar',sun?graphMix(col,'#d38b43',.46):col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false);
+  profile=graphMaterialProfile('solar',sun?graphMix(col,'#d38b43',.46):col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false,directMaterial);
  }else if(GSTYLE==='cyber'){
-  profile=graphMaterialProfile('cyber',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false);
+  profile=graphMaterialProfile('cyber',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false,directMaterial);
  }else{
-  profile=graphMaterialProfile('classic',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false);
+  profile=graphMaterialProfile('classic',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false,directMaterial);
  }
  if(node.id===GHILITE){
   graphMaterialFill(ctx,node.x,node.y,r*.76,graphAlpha('#ffffff',.065));

--- a/engraphis/static/dashboard.js
+++ b/engraphis/static/dashboard.js
@@ -958,7 +958,14 @@ function graphMaterialSprite(p,tier){
  var value={canvas:canvas,half:half,radius:radius};GRAPH_MATERIAL_CACHE.set(key,value);if(GRAPH_MATERIAL_CACHE.size>GRAPH_MATERIAL_CACHE_LIMIT)GRAPH_MATERIAL_CACHE.delete(GRAPH_MATERIAL_CACHE.keys().next().value);return value;
 }
 function graphPaintMaterialSurface(ctx,x,y,r,scale,profile,large){
- var tier=graphMaterialTier(r*Math.max(.01,scale),large),sprite=graphMaterialSprite(profile,tier);
+ var screenRadius=r*Math.max(.01,scale),tier=graphMaterialTier(screenRadius,large);
+ /* A cached full sprite is 40 CSS pixels in radius. Enlarging it beyond that turns a focused
+    hub into the blocky blob reported in Classic. Paint that exceptional visible node directly:
+    it retains the exact same Ledger material recipe, while leaves and normal-sized nodes stay
+    on the bounded cache. This is paint-only; graph data, geometry, labels, and hit testing stay
+    untouched. */
+ if(tier==='full'&&screenRadius>GRAPH_MATERIAL_RADIUS.full){graphPaintMaterialDirect(ctx,x,y,r,profile,tier);return tier}
+ var sprite=graphMaterialSprite(profile,tier);
  if(sprite&&typeof ctx.drawImage==='function'){var half=r*sprite.half/sprite.radius;ctx.drawImage(sprite.canvas,x-half,y-half,half*2,half*2)}else graphPaintMaterialDirect(ctx,x,y,r,profile,tier);
  return tier;
 }
@@ -976,15 +983,18 @@ function graphStyleNode(node,ctx,scale){
  var focus=GHOVERSET&&GHOVERSET.size>1,neighbor=focus&&GHOVERSET.has(node.id),dim=focus&&!neighbor;
  var r=node.radius,col=node.color,profile;
  ctx.globalAlpha=dim?.12:1;
+ /* The sprite cache keeps material work bounded. Detail is therefore chosen only from this
+    node's rendered size, just as in Ledger's overview; a large graph must not turn an
+    on-screen hub into a flat signature disc solely because it has many distant leaves. */
  if(GSTYLE==='galaxy'){
-  profile=graphMaterialProfile('galaxy',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,GPERF.large);
+  profile=graphMaterialProfile('galaxy',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false);
  }else if(GSTYLE==='solar'){
   var sun=node.rank===0;if(sun)r*=1.7;
-  profile=graphMaterialProfile('solar',sun?graphMix(col,'#d38b43',.46):col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,GPERF.large);
+  profile=graphMaterialProfile('solar',sun?graphMix(col,'#d38b43',.46):col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false);
  }else if(GSTYLE==='cyber'){
-  profile=graphMaterialProfile('cyber',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,GPERF.large);
+  profile=graphMaterialProfile('cyber',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false);
  }else{
-  profile=graphMaterialProfile('classic',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,GPERF.large);
+  profile=graphMaterialProfile('classic',col);graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false);
  }
  if(node.id===GHILITE){
   graphMaterialFill(ctx,node.x,node.y,r*.76,graphAlpha('#ffffff',.065));

--- a/engraphis/static/index.html
+++ b/engraphis/static/index.html
@@ -336,6 +336,6 @@
      graph view. dashboard.js fetches both on demand from graphRender(); see loadForceGraph()
      and loadGraphEngine(). scripts/externalize_dashboard_assets.py enforces both halves:
      they stay out of this file, and the lazy references still have to resolve. -->
-<script src="/static/dashboard.js?v=20260728-reference-materials"></script>
+<script src="/static/dashboard.js?v=20260728-crisp-node-materials"></script>
 </body>
 </html>

--- a/engraphis/static/index.html
+++ b/engraphis/static/index.html
@@ -336,6 +336,6 @@
      graph view. dashboard.js fetches both on demand from graphRender(); see loadForceGraph()
      and loadGraphEngine(). scripts/externalize_dashboard_assets.py enforces both halves:
      they stay out of this file, and the lazy references still have to resolve. -->
-<script src="/static/dashboard.js?v=20260728-crisp-node-materials"></script>
+<script src="/static/dashboard.js?v=20260729-hub-materials"></script>
 </body>
 </html>

--- a/tests/test_dashboard_v2.py
+++ b/tests/test_dashboard_v2.py
@@ -95,7 +95,7 @@ def test_dashboard_assets_revalidate_instead_of_pinning_old_visuals(monkeypatch,
             "/v2-assets/engraphis-graph.js?v=20260728-connected-memories",
             "/v2-assets/ledger.js?v=20260728-connected-memories",
             "/v2-assets/ledger.css?v=20260728-connected-memories",
-            "/classic-assets/dashboard.js?v=20260728-reference-materials",
+            "/classic-assets/dashboard.js?v=20260728-crisp-node-materials",
         ):
             response = client.get(path)
             assert response.status_code == 200

--- a/tests/test_dashboard_v2.py
+++ b/tests/test_dashboard_v2.py
@@ -95,7 +95,7 @@ def test_dashboard_assets_revalidate_instead_of_pinning_old_visuals(monkeypatch,
             "/v2-assets/engraphis-graph.js?v=20260728-connected-memories",
             "/v2-assets/ledger.js?v=20260728-connected-memories",
             "/v2-assets/ledger.css?v=20260728-connected-memories",
-            "/classic-assets/dashboard.js?v=20260728-crisp-node-materials",
+            "/classic-assets/dashboard.js?v=20260729-hub-materials",
         ):
             response = client.get(path)
             assert response.status_code == 200

--- a/tests/test_graph_engine_asset.py
+++ b/tests/test_graph_engine_asset.py
@@ -136,7 +136,7 @@ def test_graph_assets_are_never_loaded_on_a_plain_page_view() -> None:
     html = INDEX.read_text(encoding="utf-8")
     eager = re.findall(r'<script[^>]+src=["\'](/static/[^"\']+)["\']', html)
     assert "/static/vendor/d3.min.js" in eager
-    assert "/static/dashboard.js?v=20260728-crisp-node-materials" in eager
+    assert "/static/dashboard.js?v=20260729-hub-materials" in eager
     assert "/static/vendor/force-graph.min.js" not in eager
     assert "/static/engraphis-graph.js" not in eager
 
@@ -1955,10 +1955,11 @@ def test_legacy_classic_canvas_uses_the_same_nonwhite_material_profiles_as_ledge
         classic.index("function graphStyleBackground(")
     ]
     assert "screenRadius=r*Math.max(.01,scale),tier=graphMaterialTier(screenRadius,large)" in paint
-    assert "tier==='full'&&screenRadius>GRAPH_MATERIAL_RADIUS.full" in paint
+    assert "paintDirect&&tier==='full'&&screenRadius>GRAPH_MATERIAL_RADIUS.full" in paint
     assert "graphPaintMaterialDirect(ctx,x,y,r,profile,tier);return tier" in paint
     node_painter = classic[classic.index("function graphStyleNode("):]
-    assert node_painter.count("graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false)") == 4
+    assert "directMaterial=node.id===GHILITE||node.rank===0" in node_painter
+    assert node_painter.count("graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false,directMaterial)") == 4
     assert "profile,GPERF.large" not in node_painter
     assert classic.count("if(tier==='signature')") >= 4
 

--- a/tests/test_graph_engine_asset.py
+++ b/tests/test_graph_engine_asset.py
@@ -136,7 +136,7 @@ def test_graph_assets_are_never_loaded_on_a_plain_page_view() -> None:
     html = INDEX.read_text(encoding="utf-8")
     eager = re.findall(r'<script[^>]+src=["\'](/static/[^"\']+)["\']', html)
     assert "/static/vendor/d3.min.js" in eager
-    assert "/static/dashboard.js?v=20260728-reference-materials" in eager
+    assert "/static/dashboard.js?v=20260728-crisp-node-materials" in eager
     assert "/static/vendor/force-graph.min.js" not in eager
     assert "/static/engraphis-graph.js" not in eager
 
@@ -1947,13 +1947,19 @@ def test_legacy_classic_canvas_uses_the_same_nonwhite_material_profiles_as_ledge
     ):
         assert marker in classic
         assert marker.replace(":'", ": '") in ASSET.read_text(encoding="utf-8")
-    # The fallback selects the gradient-free signature recipe before building/painting a
-    # sprite, so hundreds of nodes keep their material identity without per-node shaders.
+    # Classic's bounded sprite cache makes the material tier a screen-space decision. A large
+    # graph still renders tiny leaves as inexpensive signatures, while a visible hub keeps the
+    # same detailed material representation as Ledger rather than degrading into a flat disc.
     paint = classic[
         classic.index("function graphPaintMaterialSurface("):
         classic.index("function graphStyleBackground(")
     ]
-    assert "graphMaterialTier(r*Math.max(.01,scale),large)" in paint
+    assert "screenRadius=r*Math.max(.01,scale),tier=graphMaterialTier(screenRadius,large)" in paint
+    assert "tier==='full'&&screenRadius>GRAPH_MATERIAL_RADIUS.full" in paint
+    assert "graphPaintMaterialDirect(ctx,x,y,r,profile,tier);return tier" in paint
+    node_painter = classic[classic.index("function graphStyleNode("):]
+    assert node_painter.count("graphPaintMaterialSurface(ctx,node.x,node.y,r,scale,profile,false)") == 4
+    assert "profile,GPERF.large" not in node_painter
     assert classic.count("if(tier==='signature')") >= 4
 
 


### PR DESCRIPTION
## What changed

- Keep Classic node material detail based on each node’s visible size, rather than downgrading every node in a large graph.
- Direct-paint oversized visible hubs with the existing Ledger material recipe instead of scaling a small cached sprite into a pixelated blob.
- Keep the Classic asset mirror synchronized and refresh the dashboard asset revision.

## Why

Classic used the low-detail signature path for large graphs and stretched a fixed-size texture for enlarged hubs. This made prominent nodes look flat or pixelated even though Ledger used richer material faces.

## Impact

This changes only canvas node painting. Graph data, layout, links, labels, hit areas, and interactions are unchanged.

## Validation

- `python -m pytest tests/test_graph_engine_asset.py tests/test_dashboard_v2.py -q`
- `ruff check tests/test_graph_engine_asset.py tests/test_dashboard_v2.py`
- `git diff --check`