### PR TITLE
fix: accept 2-part version tags in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Publish to PyPI
 on:
   push:
     tags:
+      - "v*.*"
       - "v*.*.*"
   workflow_dispatch:
     inputs:
@@ -572,7 +573,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]
           tag_ref="$(gh api "repos/${GH_REPO}/git/ref/tags/${RELEASE_TAG}")"
           object_type="$(jq -r '.object.type' <<<"$tag_ref")"
           tag_sha="$(jq -r '.object.sha' <<<"$tag_ref")"

--- a/tests/test_release_infrastructure.py
+++ b/tests/test_release_infrastructure.py
@@ -381,7 +381,7 @@ def test_release_repair_requires_tag_sha_successful_build_publish_and_pypi_ident
         "github-release-repair:", 1
     )[1]
 
-    assert '[[ "$RELEASE_TAG" =~ ^v[0-9]+\\.[0-9]+\\.[0-9]+$ ]]' in repair
+    assert '[[ "$RELEASE_TAG" =~ ^v[0-9]+\\.[0-9]+(\\.[0-9]+)?$ ]]' in repair
     assert "github.ref == 'refs/heads/main'" in repair
     assert '"repos/${GH_REPO}/git/ref/tags/${RELEASE_TAG}"' in repair
     assert '"repos/${GH_REPO}/git/tags/${tag_sha}"' in repair


### PR DESCRIPTION
Release workflow required v*.*.* (3-part semver) but version is now 1.5. Updates tag glob and bash regex to accept both 2-part and 3-part versions.