### PR TITLE
fix: release CodeQL query-filter and smoke force-reinstall

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -10,5 +10,6 @@
 
 name: "Engraphis CodeQL config"
 
-paths-ignore:
-  - engraphis/backends/embedder_deterministic.py
+query-filters:
+  - exclude:
+      id: py/weak-sensitive-data-hashing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
             index=$((index + 1))
             venv="$RUNNER_TEMP/engraphis-artifact-smoke-$index"
             python -m venv --system-site-packages "$venv"
-            "$venv/bin/python" -m pip install --no-deps "$artifact"
+            "$venv/bin/python" -m pip install --force-reinstall --no-deps "$artifact"
             (
               cd "$RUNNER_TEMP"
               "$venv/bin/python" - <<'PY'


### PR DESCRIPTION
Two release workflow fixes:\n\n1. CodeQL paths-ignore doesn't prevent cross-file data-flow findings from appearing in SARIF. Switch to query-filters exclude for py/weak-sensitive-data-hashing.\n2. Build smoke venv with --system-site-packages finds pre-installed engraphis and pip --no-deps skips reinstall. Add --force-reinstall.