### PR TITLE
fix(service): translate engine ValueError in correct() and pin()

### DIFF
--- a/engraphis/service.py
+++ b/engraphis/service.py
@@ -3991,7 +3991,7 @@ class MemoryService:
         self._check_owns(mid, wid, rid)
         try:
             return self.engine.pin(mid, pinned=bool(pinned), actor=actor)
-        except KeyError as exc:
+        except (KeyError, ValueError) as exc:
             raise ValidationError(str(exc))
 
     def correct(self, memory_id: str, new_content: str, *, workspace: str,
@@ -4005,7 +4005,7 @@ class MemoryService:
         self._check_owns(mid, wid, rid)
         try:
             return self.engine.correct(mid, new_content, reason=reason, actor=actor)
-        except KeyError as exc:
+        except (KeyError, ValueError) as exc:
             raise ValidationError(str(exc))
 
     def promote(self, memory_id: str, target_scope: str, *, workspace: str,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -991,6 +991,39 @@ def test_correct_wrong_workspace_raises_validation_error():
         s.correct(out["id"], "tampered", workspace="beta")
 
 
+def test_correct_translates_engine_value_error_to_validation_error():
+    """A ValueError from the engine must surface as ValidationError, not escape.
+
+    ``_writable_scope`` deliberately raises for a session-scoped record with no
+    session ("silently widening a session-private memory ... is a worse outcome
+    than an explicit error"). ``correct`` caught only ``KeyError``, so that
+    intentional, explicit error escaped the service layer and reached callers as
+    an opaque internal error — while ``retire``/``promote``/``merge``/
+    ``secure_erase`` all translate both.
+    """
+    s = _svc()
+    out = s.remember("A fact worth correcting.", workspace="acme")
+
+    def _boom(*a, **k):
+        raise ValueError("session scope requires session_id")
+
+    s.engine.correct = _boom
+    with pytest.raises(ValidationError, match="session scope requires"):
+        s.correct(out["id"], "replacement", workspace="acme")
+
+
+def test_pin_translates_engine_value_error_to_validation_error():
+    s = _svc()
+    out = s.remember("A fact worth pinning.", workspace="acme")
+
+    def _boom(*a, **k):
+        raise ValueError("cannot pin an expired memory")
+
+    s.engine.pin = _boom
+    with pytest.raises(ValidationError, match="cannot pin"):
+        s.pin(out["id"], workspace="acme")
+
+
 def test_promote_repo_memory_to_workspace():
     s = _svc()
     source = s.remember(


### PR DESCRIPTION
## Description

`MemoryService.correct()` and `.pin()` caught only `KeyError`, while their siblings
`retire()`, `secure_erase()`, `promote()` and `merge()` all catch `(KeyError, ValueError)`.
A `ValueError` raised by the engine therefore escaped the service layer uncaught and
reached callers as an opaque internal error rather than a `ValidationError` carrying the
message.

This matters because the engine raises `ValueError` there **deliberately**.
`_writable_scope()` documents that a session-scoped record with no session

> "still raises, because silently widening a session-private memory to repo/workspace
> visibility is a worse outcome than an explicit error"

…and `correct()` then rendered that explicit error unreadable.

### How it showed up

Through the MCP surface, a failing `engraphis_correct` returns:

```
E_INTERNAL: Error: operation failed. Check the Engraphis server logs for details.
```

— no message, no receipt. From the caller's side a rejected input is indistinguishable
from a server fault, and there is nothing in the receipt chain to review afterwards.

Worth saying explicitly, because it is the reassuring part: **nothing was lost.** The
write-then-retire ordering in `engine.correct()` means a failed replacement leaves the
original live, which we confirmed by reading the record back (content unchanged,
`valid_to` still NULL). This PR only makes the failure legible; it does not change that
ordering or any other behaviour.

### Change

Two one-line changes, making `correct()` and `pin()` consistent with the four sibling
governance methods in the same file, plus a regression test for each.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] CI/CD

## Verification

- [x] `python -m pytest tests/ -q` — passes, except two failures that **also fail on an
      unmodified checkout of `main`** in this environment and are unrelated to this change:
      `test_migration_reads_one_source_snapshot_while_a_wal_writer_commits` and
      `test_rescan_dry_run_is_read_only_and_does_not_create_sidecars` (both concern SQLite
      WAL sidecar files; macOS + Python 3.9).
- [x] `ruff check .` — passes on the changed files.
- [x] Both new tests fail without the fix (the `ValueError` escapes) and pass with it.
- [ ] `python -m eval.harness ...` — not run; this change does not touch retrieval.

## Not included

The same call path can also raise `RuntimeError` from
`remember_with_resolution()` ("the configured embedding space is not active"). That is
arguably a genuine server fault rather than a validation error, so translating it to
`ValidationError` would be wrong — but it currently surfaces just as opaquely. Left alone
here; happy to follow up if you would like the message preserved at the MCP boundary, or
a failure receipt recorded for aborted governance ops.
