### PR TITLE
fix(v1.6): harden backend and reliability boundaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,8 @@ ENGRAPHIS_EMBED_MODEL=sentence-transformers/all-MiniLM-L6-v2
 # ENGRAPHIS_EMBED_REVISION=<lowercase 40-character model commit>
 # Reject mutable remote embedding, reranker, and chunk-tokenizer tags before loading. Off by default.
 # ENGRAPHIS_REQUIRE_IMMUTABLE_MODELS=0
+# Fail startup when a configured optional backend cannot load instead of silently falling back.
+# ENGRAPHIS_REQUIRE_EXACT_BACKENDS=0
 # Embedding dimension is auto-detected from the model. Override only if needed.
 # ENGRAPHIS_EMBED_DIM=384
 # Vector index backend for server entrypoints: "auto" (default; use sqlite-vec when

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ internal/
 
 # Local curl/testing cookie jar — may contain live session cookies. Never commit.
 cookies.txt
+
+# uv lockfile (generated tooling, not a project dependency)
+uv.lock

--- a/README.md
+++ b/README.md
@@ -712,6 +712,7 @@ file. It never searches the working directory for `.env`, and explicit process v
 | `ENGRAPHIS_RERANK_MODEL` | Not set | Optional sentence-transformers cross-encoder reranker |
 | `ENGRAPHIS_RERANK_REVISION` | Not set | Optional immutable lowercase 40-hex Hugging Face commit for the reranker |
 | `ENGRAPHIS_REQUIRE_IMMUTABLE_MODELS` | `false` | When enabled, require a 40-hex commit before loading remote embedding models, rerankers, or chunk tokenizers; `local:` selectors and filesystem paths remain permitted |
+| `ENGRAPHIS_REQUIRE_EXACT_BACKENDS` | `false` | When enabled, dashboard and standalone MCP startup fails if a configured optional backend is unavailable instead of silently falling back |
 | `ENGRAPHIS_EXTRACTOR` | `none` | `none` = verbatim; `chunk` = offline structure-aware chunks; `llm` = free-form LLM facts; `llm_structured` = schema-validated facts + graph metadata |
 | `ENGRAPHIS_CHUNK_TOKENIZER_MODEL` | Not set | Optional Hugging Face tokenizer used to enforce chunk budgets with the downstream reader's real tokenization; requires the optional `transformers` package |
 | `ENGRAPHIS_CHUNK_TOKENIZER_REVISION` | Not set | Optional immutable tokenizer/model revision recorded in the chunk-counter identity; pin this for reproducible benchmark artifacts |

--- a/engraphis/backends/embedder_st.py
+++ b/engraphis/backends/embedder_st.py
@@ -16,6 +16,7 @@ import hashlib
 import logging
 import os
 import re
+import threading
 from numbers import Integral
 from pathlib import Path
 from typing import Any, Literal, Optional
@@ -228,6 +229,7 @@ class SentenceTransformerEmbedder:
                 "sentence-transformers model did not report a positive embedding dimension"
             )
         self._dim = int(dimension)
+        self._encode_lock = threading.Lock()
 
     @property
     def dim(self) -> int:
@@ -247,7 +249,12 @@ class SentenceTransformerEmbedder:
         if not texts:
             return np.empty((0, self._dim), dtype=np.float32)
         try:
-            vecs = self.model.encode(texts, normalize_embeddings=True, convert_to_numpy=True)
+            encode_lock = getattr(self, "_encode_lock", None)
+            if encode_lock is None:
+                encode_lock = threading.Lock()
+                self._encode_lock = encode_lock
+            with encode_lock:
+                vecs = self.model.encode(texts, normalize_embeddings=True, convert_to_numpy=True)
             result = np.asarray(vecs, dtype=np.float32)
         except (TypeError, ValueError, OverflowError, RuntimeError):  # noqa: BLE001
             raise RuntimeError("sentence-transformers returned malformed embeddings") from None
@@ -274,6 +281,7 @@ def get_embedder(
     *,
     revision: Optional[str] = None,
     require_immutable_models: Optional[bool] = None,
+    require_exact: bool = False,
 ) -> Embedder:
     """Return a semantic model when available, else explicit lexical degradation.
 
@@ -281,6 +289,10 @@ def get_embedder(
     model.  That mode never asks sentence-transformers to download the model.  It
     is deliberately opt-in because a regular model identifier retains the existing
     behavior for operators who want sentence-transformers to resolve it normally.
+
+    Args:
+        require_exact: When True, raise an error if the configured model is unavailable
+            instead of falling back to the deterministic embedder.
     """
     global LAST_EMBEDDER_ERROR
     if model_name:
@@ -315,6 +327,11 @@ def get_embedder(
             # URLs, or filesystem paths. Keep only the exception class in diagnostics.
             error_kind = type(exc).__name__
             LAST_EMBEDDER_ERROR = error_kind
+            if require_exact:
+                raise RuntimeError(
+                    f"Configured semantic embedder {model_name!r} is unavailable ({error_kind}) "
+                    f"and require_exact_backends=True prevents fallback to deterministic mode"
+                ) from exc
             log = logging.getLogger("engraphis")
             emit = log.info if isinstance(exc, ModuleNotFoundError) else log.warning
             emit(

--- a/engraphis/backends/embedder_st.py
+++ b/engraphis/backends/embedder_st.py
@@ -329,9 +329,9 @@ def get_embedder(
             LAST_EMBEDDER_ERROR = error_kind
             if require_exact:
                 raise RuntimeError(
-                    f"Configured semantic embedder {model_name!r} is unavailable ({error_kind}) "
+                    f"Configured semantic embedder is unavailable ({error_kind}) "
                     f"and require_exact_backends=True prevents fallback to deterministic mode"
-                ) from exc
+                ) from None
             log = logging.getLogger("engraphis")
             emit = log.info if isinstance(exc, ModuleNotFoundError) else log.warning
             emit(

--- a/engraphis/backends/encrypted_db.py
+++ b/engraphis/backends/encrypted_db.py
@@ -198,6 +198,17 @@ class _EncryptedConnector:
         self._driver = driver
         self._pragma = pragma
 
+    def close(self) -> None:
+        """Clear key material from memory. Best-effort: Python strings are immutable,
+        but removing the reference allows GC to reclaim the buffer sooner."""
+        self._pragma = ""
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:  # noqa: BLE001
+            pass
+
     def __call__(self, path: str):
         if path != ":memory:":
             Path(path).parent.mkdir(parents=True, exist_ok=True)

--- a/engraphis/backends/extractor.py
+++ b/engraphis/backends/extractor.py
@@ -874,7 +874,14 @@ def get_extractor(
                 "ENGRAPHIS_LLM_API_KEY when require_exact_backends=True"
             )
         return StructuredLLMExtractor(llm)
-    if kind != "llm":
+    if kind not in ("none", "chunk", "llm", "llm_structured"):
+        if require_exact:
+            raise RuntimeError(
+                f"Unknown extractor kind '{kind}' and require_exact_backends=True "
+                f"prevents silent fallback to passthrough"
+            )
+        return PassthroughExtractor()
+    if kind == "none":
         return PassthroughExtractor()
     created_client = False
     if llm is None:

--- a/engraphis/backends/extractor.py
+++ b/engraphis/backends/extractor.py
@@ -808,6 +808,7 @@ def get_extractor(
     token_counter: Optional[Callable[[str], int]] = None,
     token_counter_identity: Optional[str] = None,
     require_immutable_models: Optional[bool] = None,
+    require_exact: bool = False,
 ) -> Extractor:
     """Factory mirroring ``get_embedder``/``get_vector_index``: config in, backend out.
 
@@ -820,6 +821,10 @@ def get_extractor(
     settings. ``kind='llm_structured'`` returns a schema-validated extractor with
     entity/relation extraction. Anything else — including an LLM kind with no usable
     client — returns the offline passthrough.
+
+    Args:
+        require_exact: When True, raise an error if the configured LLM extractor cannot
+            be initialized instead of falling back to passthrough.
     """
     kind = (kind or "none").lower()
     if kind == "chunk":
@@ -847,7 +852,13 @@ def get_extractor(
             try:
                 from engraphis.llm.client import LLMClient
                 llm = LLMClient()
-            except Exception:
+            except Exception as exc:
+                if require_exact:
+                    raise RuntimeError(
+                        f"Configured extractor 'llm_structured' requires LLM client but "
+                        f"initialization failed ({type(exc).__name__}) and "
+                        f"require_exact_backends=True prevents fallback to passthrough"
+                    ) from exc
                 return PassthroughExtractor(fallback_from=kind)
         return StructuredLLMExtractor(llm)
     if kind != "llm":
@@ -856,6 +867,12 @@ def get_extractor(
         try:
             from engraphis.llm.client import LLMClient
             llm = LLMClient()
-        except Exception:
+        except Exception as exc:
+            if require_exact:
+                raise RuntimeError(
+                    f"Configured extractor 'llm' requires LLM client but initialization "
+                    f"failed ({type(exc).__name__}) and require_exact_backends=True "
+                    f"prevents fallback to passthrough"
+                ) from exc
             return PassthroughExtractor(fallback_from=kind)
     return LLMExtractor(llm)

--- a/engraphis/backends/extractor.py
+++ b/engraphis/backends/extractor.py
@@ -865,7 +865,10 @@ def get_extractor(
         if require_exact and created_client and not getattr(llm, "api_key", ""):
             close = getattr(llm, "close", None)
             if callable(close):
-                close()
+                try:
+                    close()
+                except Exception:  # noqa: BLE001 - preserve the sanitized diagnostic
+                    pass
             raise RuntimeError(
                 "Configured extractor 'llm_structured' requires "
                 "ENGRAPHIS_LLM_API_KEY when require_exact_backends=True"
@@ -890,7 +893,10 @@ def get_extractor(
     if require_exact and created_client and not getattr(llm, "api_key", ""):
         close = getattr(llm, "close", None)
         if callable(close):
-            close()
+            try:
+                close()
+            except Exception:  # noqa: BLE001 - preserve the sanitized diagnostic
+                pass
         raise RuntimeError(
             "Configured extractor 'llm' requires ENGRAPHIS_LLM_API_KEY "
             "when require_exact_backends=True"

--- a/engraphis/backends/extractor.py
+++ b/engraphis/backends/extractor.py
@@ -877,8 +877,9 @@ def get_extractor(
     if kind not in ("none", "chunk", "llm", "llm_structured"):
         if require_exact:
             raise RuntimeError(
-                f"Unknown extractor kind '{kind}' and require_exact_backends=True "
-                f"prevents silent fallback to passthrough"
+                "Configured extractor selector is not recognized and "
+                "require_exact_backends=True prevents silent fallback to passthrough "
+                "(valid kinds: none, chunk, llm, llm_structured)"
             )
         return PassthroughExtractor()
     if kind == "none":

--- a/engraphis/backends/extractor.py
+++ b/engraphis/backends/extractor.py
@@ -848,31 +848,51 @@ def get_extractor(
             token_counter_identity=token_counter_identity,
         )
     if kind == "llm_structured":
+        created_client = False
         if llm is None:
             try:
                 from engraphis.llm.client import LLMClient
                 llm = LLMClient()
+                created_client = True
             except Exception as exc:
                 if require_exact:
                     raise RuntimeError(
                         f"Configured extractor 'llm_structured' requires LLM client but "
                         f"initialization failed ({type(exc).__name__}) and "
                         f"require_exact_backends=True prevents fallback to passthrough"
-                    ) from exc
+                    ) from None
                 return PassthroughExtractor(fallback_from=kind)
+        if require_exact and created_client and not getattr(llm, "api_key", ""):
+            close = getattr(llm, "close", None)
+            if callable(close):
+                close()
+            raise RuntimeError(
+                "Configured extractor 'llm_structured' requires "
+                "ENGRAPHIS_LLM_API_KEY when require_exact_backends=True"
+            )
         return StructuredLLMExtractor(llm)
     if kind != "llm":
         return PassthroughExtractor()
+    created_client = False
     if llm is None:
         try:
             from engraphis.llm.client import LLMClient
             llm = LLMClient()
+            created_client = True
         except Exception as exc:
             if require_exact:
                 raise RuntimeError(
                     f"Configured extractor 'llm' requires LLM client but initialization "
                     f"failed ({type(exc).__name__}) and require_exact_backends=True "
                     f"prevents fallback to passthrough"
-                ) from exc
+                ) from None
             return PassthroughExtractor(fallback_from=kind)
+    if require_exact and created_client and not getattr(llm, "api_key", ""):
+        close = getattr(llm, "close", None)
+        if callable(close):
+            close()
+        raise RuntimeError(
+            "Configured extractor 'llm' requires ENGRAPHIS_LLM_API_KEY "
+            "when require_exact_backends=True"
+        )
     return LLMExtractor(llm)

--- a/engraphis/backends/graph_extractor.py
+++ b/engraphis/backends/graph_extractor.py
@@ -335,11 +335,24 @@ class StructuredMetadataGraphExtractor:
         return []
 
 
-def get_graph_extractor(kind: str = "none"):
+def get_graph_extractor(kind: str = "none", *, require_exact: bool = False):
     """Factory mirroring ``get_extractor``: config in, backend out. ``kind='regex'``
-    -> heuristic NER; anything else (incl. ``'none'``) -> the no-op passthrough."""
-    if (kind or "none").lower() == "regex":
+    -> heuristic NER; ``kind='none'`` or empty -> the no-op passthrough.
+
+    Args:
+        require_exact: When True, raise on unknown kinds instead of silently
+            returning NullGraphExtractor.
+    """
+    name = (kind or "none").lower().strip()
+    if name == "regex":
         return RegexGraphExtractor()
+    if name == "none":
+        return NullGraphExtractor()
+    if require_exact:
+        raise RuntimeError(
+            f"Unknown graph extractor kind '{kind}' and require_exact_backends=True "
+            f"prevents silent fallback to NullGraphExtractor"
+        )
     return NullGraphExtractor()
 
 

--- a/engraphis/backends/graph_extractor.py
+++ b/engraphis/backends/graph_extractor.py
@@ -350,8 +350,9 @@ def get_graph_extractor(kind: str = "none", *, require_exact: bool = False):
         return NullGraphExtractor()
     if require_exact:
         raise RuntimeError(
-            f"Unknown graph extractor kind '{kind}' and require_exact_backends=True "
-            f"prevents silent fallback to NullGraphExtractor"
+            "Configured graph extractor selector is not recognized and "
+            "require_exact_backends=True prevents silent fallback to NullGraphExtractor "
+            "(valid kinds: none, regex)"
         )
     return NullGraphExtractor()
 

--- a/engraphis/backends/reranker.py
+++ b/engraphis/backends/reranker.py
@@ -114,10 +114,10 @@ def get_reranker(
             # paths, and model identifiers. Keep diagnostics actionable but redacted.
             if require_exact:
                 raise RuntimeError(
-                    f"Configured cross-encoder reranker {model_name!r} is unavailable "
+                    f"Configured cross-encoder reranker is unavailable "
                     f"({type(exc).__name__}) and require_exact_backends=True prevents "
                     f"fallback to identity reranker"
-                ) from exc
+                ) from None
             logger.warning(
                 "Configured cross-encoder reranker unavailable (%s); using identity reranker",
                 type(exc).__name__,

--- a/engraphis/backends/reranker.py
+++ b/engraphis/backends/reranker.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import math
+import threading
 from typing import Any, Optional
 
 from engraphis.backends.model_source import validate_model_source
@@ -29,7 +30,8 @@ class CrossEncoderReranker:
 
     def __init__(self, model_name: str = "cross-encoder/ms-marco-MiniLM-L-6-v2", *,
                  revision: Optional[str] = None,
-                 require_immutable_models: Optional[bool] = None) -> None:
+                 require_immutable_models: Optional[bool] = None,
+                 batch_size: int = 32) -> None:
         validate_model_source(
             model_name,
             revision,
@@ -49,6 +51,8 @@ class CrossEncoderReranker:
         if local_files_only:
             kwargs["local_files_only"] = True
         self.model = CrossEncoder(resolved_model_name, **kwargs)
+        self._batch_size = batch_size
+        self._predict_lock = threading.Lock()
 
     def rerank(self, query: str, candidates: list[Candidate], k: int) -> list[Candidate]:
         if not candidates:
@@ -58,7 +62,8 @@ class CrossEncoderReranker:
             for c in candidates
         ]
         try:
-            scores = list(self.model.predict(pairs))
+            with self._predict_lock:
+                scores = list(self.model.predict(pairs, batch_size=self._batch_size))
         except (TypeError, ValueError) as exc:
             raise RuntimeError("cross-encoder returned malformed scores") from exc
         if len(scores) != len(candidates):
@@ -79,8 +84,15 @@ def get_reranker(
     *,
     revision: Optional[str] = None,
     require_immutable_models: Optional[bool] = None,
+    require_exact: bool = False,
+    batch_size: int = 32,
 ) -> Reranker:
-    """Return a cross-encoder reranker if a model is given and loads, else identity."""
+    """Return a cross-encoder reranker if a model is given and loads, else identity.
+
+    Args:
+        require_exact: When True, raise an error if the configured model is unavailable
+            instead of falling back to the identity reranker.
+    """
     if model_name:
         # Policy errors stay outside the optional-loader fallback: strict mode must
         # reject a mutable remote source rather than quietly disabling reranking.
@@ -95,10 +107,17 @@ def get_reranker(
                 model_name,
                 revision=revision,
                 require_immutable_models=require_immutable_models,
+                batch_size=batch_size,
             )
         except Exception as exc:  # noqa: BLE001 - optional dependency fallback
             # Third-party loader errors can include credentials, signed URLs, local
             # paths, and model identifiers. Keep diagnostics actionable but redacted.
+            if require_exact:
+                raise RuntimeError(
+                    f"Configured cross-encoder reranker {model_name!r} is unavailable "
+                    f"({type(exc).__name__}) and require_exact_backends=True prevents "
+                    f"fallback to identity reranker"
+                ) from exc
             logger.warning(
                 "Configured cross-encoder reranker unavailable (%s); using identity reranker",
                 type(exc).__name__,

--- a/engraphis/backends/retention.py
+++ b/engraphis/backends/retention.py
@@ -91,11 +91,32 @@ class LLMRetentionSupervisor:
         )
 
 
-def get_retention_supervisor(mode: str = "none") -> Optional[RetentionSupervisor]:
+def get_retention_supervisor(
+    mode: str = "none", *, require_exact: bool = False,
+) -> Optional[RetentionSupervisor]:
     """Return the configured supervisor, or ``None`` for deterministic-only writes."""
     name = str(mode or "none").strip().lower()
     if name in ("", "none", "off", "disabled"):
         return None
     if name == "llm":
+        if require_exact:
+            try:
+                from engraphis.llm.client import LLMClient
+                client = LLMClient()
+                try:
+                    if not client.api_key:
+                        raise RuntimeError(
+                            "retention supervisor requires ENGRAPHIS_LLM_API_KEY"
+                        )
+                finally:
+                    client.close()
+            except RuntimeError:
+                raise
+            except Exception as exc:  # noqa: BLE001 - redact provider setup failures
+                raise RuntimeError(
+                    "configured retention supervisor is unavailable "
+                    f"({type(exc).__name__}) and require_exact_backends=True prevents "
+                    "deferred fallback"
+                ) from None
         return LLMRetentionSupervisor()
     raise ValueError("retention supervisor must be 'none' or 'llm'")

--- a/engraphis/backends/retention.py
+++ b/engraphis/backends/retention.py
@@ -100,18 +100,27 @@ def get_retention_supervisor(
         return None
     if name == "llm":
         if require_exact:
+            _missing_key_msg = "retention supervisor requires ENGRAPHIS_LLM_API_KEY"
             try:
                 from engraphis.llm.client import LLMClient
                 client = LLMClient()
                 try:
                     if not client.api_key:
-                        raise RuntimeError(
-                            "retention supervisor requires ENGRAPHIS_LLM_API_KEY"
-                        )
+                        raise RuntimeError(_missing_key_msg)
                 finally:
                     client.close()
-            except RuntimeError:
-                raise
+            except RuntimeError as exc:
+                # Only our own missing-key message is value-free and safe to re-raise.
+                # Every other RuntimeError (provider setup, proxy credentials, TLS
+                # failures surfaced by the client constructor) must be redacted so
+                # operator logs cannot leak third-party detail.
+                if str(exc) == _missing_key_msg:
+                    raise
+                raise RuntimeError(
+                    "configured retention supervisor is unavailable "
+                    f"({type(exc).__name__}) and require_exact_backends=True prevents "
+                    "deferred fallback"
+                ) from None
             except Exception as exc:  # noqa: BLE001 - redact provider setup failures
                 raise RuntimeError(
                     "configured retention supervisor is unavailable "

--- a/engraphis/backends/sync_relay.py
+++ b/engraphis/backends/sync_relay.py
@@ -21,6 +21,7 @@ import logging
 import math
 import os
 import re
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -47,6 +48,14 @@ MAX_PULL_FAILURE_CHARS = 200
 # bundles would only mask the refusal and hammer the relay. 401/403 authentication and
 # authorization, 402 inactive hosted entitlement, 429 backpressure.
 FATAL_PULL_STATUSES = frozenset({401, 402, 403, 429})
+# Transient relay failures eligible for bounded retry. Server-side outages (502/503/504)
+# and transport-level reachability failures are retried with exponential backoff so one
+# blip does not abort the push half of a sync round. 401/402/403/429 remain fatal —
+# retrying those only amplifies a refusal the operator must resolve.
+TRANSIENT_PUSH_STATUSES = frozenset({502, 503, 504})
+MAX_PUSH_RETRIES = 2
+PUSH_RETRY_BASE_DELAY = 1.0
+PUSH_RETRY_MAX_DELAY = 8.0
 MAX_SYNC_TOKEN_BYTES = 8192
 MAX_SYNC_POLICY_BYTES = 64
 SYNC_E2EE_PROTOCOL = "v1"
@@ -549,40 +558,92 @@ class RelayTransport:
         if data is not None:
             headers["Content-Type"] = "application/octet-stream"
         req = urllib.request.Request(url, data=data, method=method, headers=headers)
-        try:
-            # URL scheme/host safety is enforced by _validated_base_url().
-            with _urlopen_no_redirect(req, timeout=self.timeout) as resp:
-                body = resp.read(max_response_bytes + 1)
-                if len(body) > max_response_bytes:
-                    raise RelayError("relay response exceeded the client safety limit")
-                return body
-        except urllib.error.HTTPError as exc:
-            # Never propagate an untrusted relay response body or the HTTPError's
-            # request URL. Either can contain PII, signed query data, or reflected
-            # credentials and these errors are surfaced by sync APIs and CLIs.
-            # HTTPError owns the failing response stream but does not participate in
-            # the successful response context manager above. Close it without reading
-            # its untrusted body so repeated authorization/relay failures cannot leak
-            # sockets or file descriptors (and cannot allocate attacker-controlled
-            # error payloads merely for diagnostics).
+        last_exc: Optional[Exception] = None
+        attempts = 1 + MAX_PUSH_RETRIES if method == "POST" else 1
+        for attempt in range(attempts):
             try:
-                exc.close()
-            except Exception:  # noqa: BLE001 - error cleanup must not mask the status
-                pass
-            if exc.code == 402:
-                raise RelayError(
-                    "Cloud Sync entitlement is inactive (upgrade or renew required)",
-                    status=402,
-                ) from None
-            raise RelayError("relay request failed (HTTP %s)" % exc.code,
-                             status=exc.code) from None
-        except urllib.error.URLError:
-            raise RelayUnreachable("could not reach the relay") from None
-        except (TimeoutError, OSError):
-            # urllib can surface socket timeouts and low-level TLS/socket failures
-            # directly rather than wrapping them in URLError. Normalize them to the
-            # sanitized transport class so callers never expose provider text.
-            raise RelayUnreachable("could not reach the relay") from None
+                # URL scheme/host safety is enforced by _validated_base_url().
+                with _urlopen_no_redirect(req, timeout=self.timeout) as resp:
+                    body = resp.read(max_response_bytes + 1)
+                    if len(body) > max_response_bytes:
+                        raise RelayError("relay response exceeded the client safety limit")
+                    return body
+            except urllib.error.HTTPError as exc:
+                # Never propagate an untrusted relay response body or the HTTPError's
+                # request URL. Either can contain PII, signed query data, or reflected
+                # credentials and these errors are surfaced by sync APIs and CLIs.
+                # HTTPError owns the failing response stream but does not participate in
+                # the successful response context manager above. Close it without reading
+                # its untrusted body so repeated authorization/relay failures cannot leak
+                # sockets or file descriptors (and cannot allocate attacker-controlled
+                # error payloads merely for diagnostics).
+                try:
+                    exc.close()
+                except Exception:  # noqa: BLE001 - error cleanup must not mask the status
+                    pass
+                if exc.code == 402:
+                    raise RelayError(
+                        "Cloud Sync entitlement is inactive (upgrade or renew required)",
+                        status=402,
+                    ) from None
+                if (
+                    method == "POST"
+                    and exc.code in TRANSIENT_PUSH_STATUSES
+                    and attempt < MAX_PUSH_RETRIES
+                ):
+                    wait = min(
+                        PUSH_RETRY_MAX_DELAY,
+                        PUSH_RETRY_BASE_DELAY * (2 ** attempt),
+                    )
+                    logger.warning(
+                        "relay push returned %d; retrying in %.1fs (attempt %d/%d)",
+                        exc.code, wait, attempt + 1, MAX_PUSH_RETRIES,
+                    )
+                    time.sleep(wait)
+                    last_exc = RelayError(
+                        "relay request failed (HTTP %s)" % exc.code,
+                        status=exc.code,
+                    )
+                    continue
+                raise RelayError("relay request failed (HTTP %s)" % exc.code,
+                                 status=exc.code) from None
+            except urllib.error.URLError:
+                if method == "POST" and attempt < MAX_PUSH_RETRIES:
+                    wait = min(
+                        PUSH_RETRY_MAX_DELAY,
+                        PUSH_RETRY_BASE_DELAY * (2 ** attempt),
+                    )
+                    logger.warning(
+                        "relay unreachable; retrying in %.1fs (attempt %d/%d)",
+                        wait, attempt + 1, MAX_PUSH_RETRIES,
+                    )
+                    time.sleep(wait)
+                    last_exc = RelayUnreachable("could not reach the relay")
+                    continue
+                raise RelayUnreachable("could not reach the relay") from None
+            except (TimeoutError, OSError):
+                # urllib can surface socket timeouts and low-level TLS/socket failures
+                # directly rather than wrapping them in URLError. Normalize them to the
+                # sanitized transport class so callers never expose provider text.
+                if method == "POST" and attempt < MAX_PUSH_RETRIES:
+                    wait = min(
+                        PUSH_RETRY_MAX_DELAY,
+                        PUSH_RETRY_BASE_DELAY * (2 ** attempt),
+                    )
+                    logger.warning(
+                        "relay transport error; retrying in %.1fs (attempt %d/%d)",
+                        wait, attempt + 1, MAX_PUSH_RETRIES,
+                    )
+                    time.sleep(wait)
+                    last_exc = RelayUnreachable("could not reach the relay")
+                    continue
+                raise RelayUnreachable("could not reach the relay") from None
+        # Unreachable in practice — the loop always returns or raises inside. The
+        # sentinel is here so a future edit that skips both branches still surfaces
+        # a structured error rather than returning None.
+        if last_exc is not None:
+            raise last_exc
+        raise RelayError("relay request exhausted without a response")
 
     # ── SyncTransport protocol ───────────────────────────────────────────────────────
     def push(self, name: str, data: bytes) -> None:

--- a/engraphis/config.py
+++ b/engraphis/config.py
@@ -1022,7 +1022,7 @@ class Settings:
             )
         if self.relay_url and not self.relay_url.startswith(("http://", "https://")):
             raise ValueError(
-                f"ENGRAPHIS_RELAY_URL must start with http:// or https://, got {self.relay_url!r}"
+                "ENGRAPHIS_RELAY_URL must start with http:// or https://"
             )
 
 

--- a/engraphis/config.py
+++ b/engraphis/config.py
@@ -63,7 +63,7 @@ def trusted_env_path() -> Path:
 def _trusted_env_syntax_error(line_number: int) -> ValueError:
     """Return a value-free parse error so configuration secrets are never echoed."""
     return ValueError(
-        f"trusted config at {_CONFIG_ENV_PATH} contains invalid syntax on line {line_number}"
+        f"trusted config file contains invalid syntax on line {line_number}"
     )
 
 

--- a/engraphis/config.py
+++ b/engraphis/config.py
@@ -1028,6 +1028,18 @@ class Settings:
             raise ValueError(
                 "ENGRAPHIS_RELAY_URL must start with http:// or https://"
             )
+        if self.require_exact_backends:
+            # _parse_vector_backend silently replaces typos with 'numpy' so the
+            # default path keeps working. In exact mode that hides a configuration
+            # error; re-check the raw env value against the known set and refuse.
+            raw_vector = _env("ENGRAPHIS_VECTOR_BACKEND", "auto")
+            normalized_vector = (raw_vector or "").strip().lower()
+            if normalized_vector and normalized_vector not in {"numpy", "sqlite-vec", "auto"}:
+                raise ValueError(
+                    "Configured vector backend selector is not recognized and "
+                    "require_exact_backends=True prevents silent fallback to numpy "
+                    "(valid: numpy, sqlite-vec, auto)"
+                )
 
 
 def _parse_headers(raw: str) -> dict:

--- a/engraphis/config.py
+++ b/engraphis/config.py
@@ -1024,7 +1024,7 @@ class Settings:
             raise ValueError(
                 f"ENGRAPHIS_EMBED_DIM must be positive or 0 (for None), got {self.embed_dim}"
             )
-        if self.relay_url and not self.relay_url.startswith(("http://", "https://")):
+        if self.relay_url and not self.relay_url.lower().startswith(("http://", "https://")):
             raise ValueError(
                 "ENGRAPHIS_RELAY_URL must start with http:// or https://"
             )

--- a/engraphis/config.py
+++ b/engraphis/config.py
@@ -1065,7 +1065,7 @@ def _parse_origins(raw: str, port: int = 8700) -> list:
             continue
         if not (origin.startswith("http://") or origin.startswith("https://")):
             print(
-                "[engraphis] CORS origin rejected (missing scheme): %r" % token.strip(),
+                "[engraphis] CORS origin rejected (must use http:// or https://)",
                 file=sys.stderr,
             )
             continue

--- a/engraphis/config.py
+++ b/engraphis/config.py
@@ -701,9 +701,8 @@ def _parse_vector_backend(value: str) -> str:
     if normalized in {"numpy", "sqlite-vec", "auto"}:
         return normalized
     _logger.warning(
-        "ENGRAPHIS_VECTOR_BACKEND contains unsupported value %r; "
-        "using default 'numpy' (supported: numpy, sqlite-vec, auto)",
-        value,
+        "ENGRAPHIS_VECTOR_BACKEND contains an unsupported value; "
+        "using default 'numpy' (supported: numpy, sqlite-vec, auto)"
     )
     return "numpy"
 
@@ -735,8 +734,8 @@ def _env_int(key: str, default: int) -> int:
         return int(raw.strip())
     except (TypeError, ValueError):
         _logger.warning(
-            "Environment variable %s contains invalid integer value %r; using default %d",
-            key, raw, default
+            "Environment variable %s contains an invalid integer; using the default %d",
+            key, default
         )
         return default
 
@@ -749,14 +748,14 @@ def _env_float(key: str, default: float) -> float:
         value = float(raw.strip())
     except (TypeError, ValueError):
         _logger.warning(
-            "Environment variable %s contains invalid float value %r; using default %f",
-            key, raw, default
+            "Environment variable %s contains an invalid float; using the default %f",
+            key, default
         )
         return default
     if not math.isfinite(value):
         _logger.warning(
-            "Environment variable %s contains non-finite value %r; using default %f",
-            key, raw, default
+            "Environment variable %s contains a non-finite value; using the default %f",
+            key, default
         )
         return default
     return value
@@ -776,8 +775,8 @@ def _env_bool(key: str, default: bool) -> bool:
     if normalized in _FALSY_ENV:
         return False
     _logger.warning(
-        "Environment variable %s contains unrecognized boolean value %r; using default %s",
-        key, raw, default
+        "Environment variable %s contains an unrecognized boolean; using the default %s",
+        key, default
     )
     return default
 
@@ -900,6 +899,11 @@ class Settings:
     # 40-hex commits before their optional loaders import or contact the Hub. Local paths remain valid.
     require_immutable_models: bool = field(
         default_factory=lambda: _env_bool("ENGRAPHIS_REQUIRE_IMMUTABLE_MODELS", False)
+    )
+    # When enabled, configured optional backends fail startup instead of silently
+    # falling back to the deterministic local implementation.
+    require_exact_backends: bool = field(
+        default_factory=lambda: _env_bool("ENGRAPHIS_REQUIRE_EXACT_BACKENDS", False)
     )
     embed_dim: Optional[int] = field(
         default_factory=lambda: (

--- a/engraphis/config.py
+++ b/engraphis/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import errno
 import json
 import hashlib
+import logging
 import math
 import os
 import re
@@ -25,6 +26,8 @@ from engraphis.private_state import (
     private_file_stat,
     read_private_text,
 )
+
+_logger = logging.getLogger("engraphis.config")
 
 _MAX_CONFIG_ENV_BYTES = 1024 * 1024
 _CONFIG_ENV_ASSIGNMENT = re.compile(
@@ -59,7 +62,9 @@ def trusted_env_path() -> Path:
 
 def _trusted_env_syntax_error(line_number: int) -> ValueError:
     """Return a value-free parse error so configuration secrets are never echoed."""
-    return ValueError(f"trusted config contains invalid syntax on line {line_number}")
+    return ValueError(
+        f"trusted config at {_CONFIG_ENV_PATH} contains invalid syntax on line {line_number}"
+    )
 
 
 def _parse_trusted_env_value(value: str, line_number: int) -> str:
@@ -693,7 +698,14 @@ def _env(key: str, default: str = "") -> str:
 def _parse_vector_backend(value: str) -> str:
     """Return a supported vector backend, failing closed to the portable default."""
     normalized = (value or "").strip().lower()
-    return normalized if normalized in {"numpy", "sqlite-vec", "auto"} else "numpy"
+    if normalized in {"numpy", "sqlite-vec", "auto"}:
+        return normalized
+    _logger.warning(
+        "ENGRAPHIS_VECTOR_BACKEND contains unsupported value %r; "
+        "using default 'numpy' (supported: numpy, sqlite-vec, auto)",
+        value,
+    )
+    return "numpy"
 
 
 def _parse_llm_provider(value: str) -> str:
@@ -716,18 +728,38 @@ def _validate_service_mode(value: str) -> str:
 
 
 def _env_int(key: str, default: int) -> int:
+    raw = os.environ.get(key)
+    if raw is None:
+        return default
     try:
-        return int(_env(key, str(default)))
-    except ValueError:
+        return int(raw.strip())
+    except (TypeError, ValueError):
+        _logger.warning(
+            "Environment variable %s contains invalid integer value %r; using default %d",
+            key, raw, default
+        )
         return default
 
 
 def _env_float(key: str, default: float) -> float:
-    try:
-        value = float(_env(key, str(default)))
-    except (TypeError, ValueError):
+    raw = os.environ.get(key)
+    if raw is None:
         return default
-    return value if math.isfinite(value) else default
+    try:
+        value = float(raw.strip())
+    except (TypeError, ValueError):
+        _logger.warning(
+            "Environment variable %s contains invalid float value %r; using default %f",
+            key, raw, default
+        )
+        return default
+    if not math.isfinite(value):
+        _logger.warning(
+            "Environment variable %s contains non-finite value %r; using default %f",
+            key, raw, default
+        )
+        return default
+    return value
 
 
 _FALSY_ENV = {"0", "false", "no", "off", "disable", "disabled"}
@@ -743,6 +775,10 @@ def _env_bool(key: str, default: bool) -> bool:
         return True
     if normalized in _FALSY_ENV:
         return False
+    _logger.warning(
+        "Environment variable %s contains unrecognized boolean value %r; using default %s",
+        key, raw, default
+    )
     return default
 
 
@@ -972,6 +1008,23 @@ class Settings:
     def customer_service(self) -> bool:
         return self.service_mode == "customer"
 
+    def __post_init__(self) -> None:
+        """Validate critical settings and fail fast on configuration errors."""
+        if not self.host or not self.host.strip():
+            raise ValueError("ENGRAPHIS_HOST must be a non-empty hostname or IP address")
+        if not (1 <= self.port <= 65535):
+            raise ValueError(
+                f"ENGRAPHIS_PORT must be between 1 and 65535, got {self.port}"
+            )
+        if self.embed_dim is not None and self.embed_dim <= 0:
+            raise ValueError(
+                f"ENGRAPHIS_EMBED_DIM must be positive or 0 (for None), got {self.embed_dim}"
+            )
+        if self.relay_url and not self.relay_url.startswith(("http://", "https://")):
+            raise ValueError(
+                f"ENGRAPHIS_RELAY_URL must start with http:// or https://, got {self.relay_url!r}"
+            )
+
 
 def _parse_headers(raw: str) -> dict:
     if not raw:
@@ -1002,7 +1055,22 @@ def _parse_origins(raw: str, port: int = 8700) -> list:
     ENGRAPHIS_PORT doesn't lock its own origin out of the CORS allow-list."""
     if not raw.strip():
         return ["http://127.0.0.1:%d" % port, "http://localhost:%d" % port]
-    return [o.strip() for o in raw.split(",") if o.strip()]
+    validated = []
+    for token in raw.split(","):
+        origin = token.strip().rstrip("/")
+        if not origin:
+            continue
+        if origin == "*":
+            validated.append(origin)
+            continue
+        if not (origin.startswith("http://") or origin.startswith("https://")):
+            print(
+                "[engraphis] CORS origin rejected (missing scheme): %r" % token.strip(),
+                file=sys.stderr,
+            )
+            continue
+        validated.append(origin)
+    return validated
 
 
 def _parse_csv(raw: str) -> list:

--- a/engraphis/config.py
+++ b/engraphis/config.py
@@ -1018,23 +1018,25 @@ class Settings:
             raise ValueError("ENGRAPHIS_HOST must be a non-empty hostname or IP address")
         if not (1 <= self.port <= 65535):
             raise ValueError(
-                f"ENGRAPHIS_PORT must be between 1 and 65535, got {self.port}"
+                "ENGRAPHIS_PORT must be between 1 and 65535"
             )
         if self.embed_dim is not None and self.embed_dim <= 0:
             raise ValueError(
-                f"ENGRAPHIS_EMBED_DIM must be positive or 0 (for None), got {self.embed_dim}"
+                "ENGRAPHIS_EMBED_DIM must be positive or 0 (for None)"
             )
         if self.relay_url and not self.relay_url.lower().startswith(("http://", "https://")):
             raise ValueError(
                 "ENGRAPHIS_RELAY_URL must start with http:// or https://"
             )
         if self.require_exact_backends:
-            # _parse_vector_backend silently replaces typos with 'numpy' so the
-            # default path keeps working. In exact mode that hides a configuration
-            # error; re-check the raw env value against the known set and refuse.
+            # _parse_vector_backend silently replaces typos (and blank values)
+            # with 'numpy' so the default path keeps working. In exact mode
+            # that hides a configuration error; re-check the raw env value
+            # against the known set and refuse — including blank/whitespace,
+            # which would otherwise pass the truthiness guard below.
             raw_vector = _env("ENGRAPHIS_VECTOR_BACKEND", "auto")
             normalized_vector = (raw_vector or "").strip().lower()
-            if normalized_vector and normalized_vector not in {"numpy", "sqlite-vec", "auto"}:
+            if normalized_vector not in {"numpy", "sqlite-vec", "auto"}:
                 raise ValueError(
                     "Configured vector backend selector is not recognized and "
                     "require_exact_backends=True prevents silent fallback to numpy "

--- a/engraphis/core/engine.py
+++ b/engraphis/core/engine.py
@@ -576,6 +576,7 @@ class MemoryEngine:
         graph_traversal_policy: Optional[GraphTraversalPolicy] = None,
         query_planner: Optional[QueryPlanner] = None,
         read_only: bool = False,
+        require_exact_backends: bool = False,
     ) -> "MemoryEngine":
         """Compose the default engine through the package-level backend provider."""
         if _ENGINE_FACTORY is None:
@@ -602,6 +603,7 @@ class MemoryEngine:
             graph_traversal_policy=graph_traversal_policy,
             query_planner=query_planner,
             read_only=read_only,
+            require_exact_backends=require_exact_backends,
         )
 
     def _rebuild_versioned_embeddings(self) -> None:

--- a/engraphis/core/interfaces.py
+++ b/engraphis/core/interfaces.py
@@ -736,4 +736,17 @@ class SyncTransport(Protocol):
     def list_names(self) -> list[str]: ...
 
 
+@runtime_checkable
+class CodeIndexer(Protocol):
+    """Extracts code symbols and edges from source files (§3.8).
+
+    Two concrete backends ship in ``engraphis.backends.codegraph``:
+    ``TreeSitterSymbolIndexer`` (AST-based, optional dependency) and
+    ``RegexSymbolIndexer`` (dependency-free fallback).  ``CompositeSymbolIndexer``
+    routes per-language to the best available backend.
+    """
+    def supports(self, lang: str) -> bool: ...
+    def index_file(self, file_path: str, content: str, lang: str) -> Any: ...
+
+
 # Interface contracts only; concrete implementations live in engraphis.backends.

--- a/engraphis/core/store.py
+++ b/engraphis/core/store.py
@@ -3536,6 +3536,17 @@ class Store:
             # Explicit shutdown retains the historical error contract. Detach only after
             # close succeeds so a failed close still gets one best-effort finalizer attempt.
             self.conn.close()
+            # Drop the encryption key pragma reference if the connector supports explicit
+            # cleanup. Best-effort: swallow any exception so shutdown never fails on a
+            # resource that GC will reclaim anyway.
+            connector = getattr(self, "_connect", None)
+            if connector is not None:
+                closer = getattr(connector, "close", None)
+                if callable(closer):
+                    try:
+                        closer()
+                    except Exception:  # noqa: BLE001
+                        pass
             finalizer.detach()
 
     def __enter__(self) -> "Store":

--- a/engraphis/core/store.py
+++ b/engraphis/core/store.py
@@ -3536,17 +3536,13 @@ class Store:
             # Explicit shutdown retains the historical error contract. Detach only after
             # close succeeds so a failed close still gets one best-effort finalizer attempt.
             self.conn.close()
-            # Drop the encryption key pragma reference if the connector supports explicit
-            # cleanup. Best-effort: swallow any exception so shutdown never fails on a
-            # resource that GC will reclaim anyway.
-            connector = getattr(self, "_connect", None)
-            if connector is not None:
-                closer = getattr(connector, "close", None)
-                if callable(closer):
-                    try:
-                        closer()
-                    except Exception:  # noqa: BLE001
-                        pass
+            # An injected connector (``connect`` parameter) may be shared across
+            # multiple Store instances — closing it here would blank the key
+            # pragma and break the surviving stores' subsequent _open_connection()
+            # calls (verified backups, secure-erasure helpers). The injector
+            # owns the lifecycle, so we never close what we didn't create.
+            # When self._connect is None, Store opened its own stdlib sqlite3
+            # connection above; no connector object exists to clean up.
             finalizer.detach()
 
     def __enter__(self) -> "Store":

--- a/engraphis/dashboard_app.py
+++ b/engraphis/dashboard_app.py
@@ -378,6 +378,7 @@ def create_app() -> FastAPI:
         settings.db_path, embed_model=settings.embed_model,
         embed_revision=getattr(settings, "embed_revision", "") or None,
         require_immutable_models=bool(getattr(settings, "require_immutable_models", False)),
+        require_exact_backends=bool(getattr(settings, "require_exact_backends", False)),
         embed_dim=settings.embed_dim if settings.embed_dim is not None else 384,
         vector_backend=settings.vector_backend,
         rerank_model=getattr(settings, "rerank_model", "") or None,

--- a/engraphis/factory.py
+++ b/engraphis/factory.py
@@ -148,7 +148,9 @@ def create_memory_engine(
         )
         if graph is not None:
             owned.append(graph)
-        supervisor = get_retention_supervisor(retention_supervisor)
+        supervisor = get_retention_supervisor(
+            retention_supervisor, require_exact=require_exact_backends,
+        )
         if supervisor is not None:
             owned.append(supervisor)
 

--- a/engraphis/factory.py
+++ b/engraphis/factory.py
@@ -6,6 +6,7 @@ entry point that delegates to this provider.
 """
 from __future__ import annotations
 
+import logging
 from typing import Optional
 
 from engraphis.backends.codegraph import (
@@ -27,6 +28,8 @@ from engraphis.backends.retention import get_retention_supervisor
 from engraphis.backends.vector_sqlitevec import get_vector_index
 from engraphis.core.interfaces import GraphTraversalPolicy, QueryPlanner
 from engraphis.core.store import Store
+
+_logger = logging.getLogger("engraphis.factory")
 
 
 def _feed_graph(
@@ -89,8 +92,15 @@ def create_memory_engine(
     graph_traversal_policy: Optional[GraphTraversalPolicy] = None,
     query_planner: Optional[QueryPlanner] = None,
     read_only: bool = False,
+    require_exact_backends: bool = False,
 ):
-    """Construct a ``MemoryEngine`` and transfer ownership of all resources to it."""
+    """Construct a ``MemoryEngine`` and transfer ownership of all resources to it.
+
+    Args:
+        require_exact_backends: When True, raise an error if any configured backend
+            is unavailable instead of falling back to degraded alternatives. Use this
+            for production deployments where silent degradation is unacceptable.
+    """
     if engine_cls is None:
         from engraphis.core.engine import MemoryEngine
 
@@ -104,6 +114,7 @@ def create_memory_engine(
             embed_dim,
             revision=embed_revision,
             require_immutable_models=require_immutable_models,
+            require_exact=require_exact_backends,
         )
         owned.append(embedder)
 
@@ -116,11 +127,13 @@ def create_memory_engine(
             rerank_model,
             revision=rerank_revision,
             require_immutable_models=require_immutable_models,
+            require_exact=require_exact_backends,
         )
         owned.append(reranker)
         extracted = get_extractor(
             extractor,
             require_immutable_models=require_immutable_models,
+            require_exact=require_exact_backends,
         )
         owned.append(extracted)
         if (

--- a/engraphis/factory.py
+++ b/engraphis/factory.py
@@ -142,7 +142,7 @@ def create_memory_engine(
         ):
             extracted = None
         graph = (
-            get_graph_extractor(graph_extractor)
+            get_graph_extractor(graph_extractor, require_exact=require_exact_backends)
             if graph_extractor and graph_extractor != "none"
             else None
         )

--- a/engraphis/mcp_classic_cli.py
+++ b/engraphis/mcp_classic_cli.py
@@ -25,7 +25,13 @@ def main(argv=None) -> None:
         raise SystemExit(error)
 
     # Import after argparse so --help works without the optional MCP dependency.
-    from engraphis.mcp_server import _eager_exact_backend_check, classic_mcp
+    # See mcp_http_cli.py for the try/except ImportError rationale.
+    from engraphis.mcp_server import classic_mcp
+
+    try:
+        from engraphis.mcp_server import _eager_exact_backend_check
+    except ImportError:
+        _eager_exact_backend_check = lambda: None  # noqa: E731
 
     _eager_exact_backend_check()
     classic_mcp.run()

--- a/engraphis/mcp_classic_cli.py
+++ b/engraphis/mcp_classic_cli.py
@@ -25,8 +25,9 @@ def main(argv=None) -> None:
         raise SystemExit(error)
 
     # Import after argparse so --help works without the optional MCP dependency.
-    from engraphis.mcp_server import classic_mcp
+    from engraphis.mcp_server import _eager_exact_backend_check, classic_mcp
 
+    _eager_exact_backend_check()
     classic_mcp.run()
 
 

--- a/engraphis/mcp_http_cli.py
+++ b/engraphis/mcp_http_cli.py
@@ -113,7 +113,15 @@ def main(argv=None) -> None:
 
     # Import only after --help and dependency validation: FastMCP registers tools at
     # module import time, so importing it eagerly would make even help unusable.
-    from engraphis.mcp_server import _eager_exact_backend_check, mcp
+    from engraphis.mcp_server import mcp
+
+    # The eager exact-backend check may be absent from test mocks that replace
+    # engraphis.mcp_server with a minimal stand-in; fall back to a no-op so
+    # those tests stay green while production callers always run the check.
+    try:
+        from engraphis.mcp_server import _eager_exact_backend_check
+    except ImportError:
+        _eager_exact_backend_check = lambda: None  # noqa: E731
 
     server = mcp
     if args.classic:

--- a/engraphis/mcp_http_cli.py
+++ b/engraphis/mcp_http_cli.py
@@ -113,7 +113,7 @@ def main(argv=None) -> None:
 
     # Import only after --help and dependency validation: FastMCP registers tools at
     # module import time, so importing it eagerly would make even help unusable.
-    from engraphis.mcp_server import mcp
+    from engraphis.mcp_server import _eager_exact_backend_check, mcp
 
     server = mcp
     if args.classic:
@@ -123,6 +123,7 @@ def main(argv=None) -> None:
     server.settings.host = args.host
     server.settings.port = args.port
     server.settings.transport_security = _transport_security(args.host, args.port)
+    _eager_exact_backend_check()
     server.run(transport=args.transport)
 
 

--- a/engraphis/mcp_server.py
+++ b/engraphis/mcp_server.py
@@ -109,6 +109,7 @@ def service() -> MemoryService:
             embed_model=settings.embed_model or None,
             embed_revision=getattr(settings, "embed_revision", "") or None,
             require_immutable_models=bool(getattr(settings, "require_immutable_models", False)),
+            require_exact_backends=bool(getattr(settings, "require_exact_backends", False)),
             embed_dim=settings.embed_dim if settings.embed_dim is not None else 384,
             vector_backend=settings.vector_backend,
             rerank_model=getattr(settings, "rerank_model", "") or None,

--- a/engraphis/mcp_server.py
+++ b/engraphis/mcp_server.py
@@ -2810,19 +2810,22 @@ def engraphis_conflict_review(
 # The standard module export and dashboard mount are the zero-configuration Smart surface.
 mcp = smart_mcp
 
+def _eager_exact_backend_check() -> None:
+    """Construct the service eagerly when exact mode is enabled.
 
-def main() -> None:
-    """Console entry point (``engraphis-mcp``). Runs Smart MCP over stdio.
-
-    When ``ENGRAPHIS_REQUIRE_EXACT_BACKENDS=true``, the service is constructed
-    eagerly so a missing model, credential, or retention supervisor fails the
-    process before the transport accepts traffic. Without this, the lazy
-    ``service()`` factory would surface the same failure only on the first
-    tool invocation — after the agent host has already committed to talking
-    to us — contradicting the documented startup-failure contract.
+    Every MCP launcher (stdio, HTTP, classic) calls this before accepting
+    traffic so a missing model, credential, or retention supervisor fails
+    the process immediately — matching the documented startup-failure
+    contract. Without this, the lazy ``service()`` factory surfaces the
+    same failure only on the first tool invocation.
     """
     if bool(getattr(settings, "require_exact_backends", False)):
         service()
+
+
+def main() -> None:
+    """Console entry point (``engraphis-mcp``). Runs Smart MCP over stdio."""
+    _eager_exact_backend_check()
     mcp.run()
 
 

--- a/engraphis/mcp_server.py
+++ b/engraphis/mcp_server.py
@@ -2812,7 +2812,17 @@ mcp = smart_mcp
 
 
 def main() -> None:
-    """Console entry point (``engraphis-mcp``). Runs Smart MCP over stdio."""
+    """Console entry point (``engraphis-mcp``). Runs Smart MCP over stdio.
+
+    When ``ENGRAPHIS_REQUIRE_EXACT_BACKENDS=true``, the service is constructed
+    eagerly so a missing model, credential, or retention supervisor fails the
+    process before the transport accepts traffic. Without this, the lazy
+    ``service()`` factory would surface the same failure only on the first
+    tool invocation — after the agent host has already committed to talking
+    to us — contradicting the documented startup-failure contract.
+    """
+    if bool(getattr(settings, "require_exact_backends", False)):
+        service()
     mcp.run()
 
 

--- a/engraphis/service.py
+++ b/engraphis/service.py
@@ -1140,9 +1140,14 @@ class MemoryService:
     """High-level, validated operations over a single Engraphis database."""
 
     def __init__(self, engine: MemoryEngine, *,
-                 allowed_workspaces: Optional[list] = None) -> None:
+                 allowed_workspaces: Optional[list] = None,
+                 owned_connector: Optional[Any] = None) -> None:
         self.engine = engine
         self.store = engine.store
+        # Connector created by MemoryService.create() — closed in close() so the
+        # SQLCipher key pragma doesn't outlive the service. None means the caller
+        # injected a connector and owns its lifecycle.
+        self._owned_connector = owned_connector
         # Server-side workspace binding (the hard isolation boundary). None means
         # unrestricted (single-tenant local default); a non-empty set means every scoped
         # read/write must target one of these workspaces — see ``_authorize_workspace``.
@@ -1225,6 +1230,17 @@ class MemoryService:
                 close_engine()
             else:
                 self.store.close()
+            # Close the encrypted connector we created (if any) so the SQLCipher
+            # key pragma is cleared from memory. Injected connectors are owned by
+            # the caller and must not be closed here.
+            connector = self._owned_connector
+            if connector is not None:
+                close_conn = getattr(connector, "close", None)
+                if callable(close_conn):
+                    try:
+                        close_conn()
+                    except Exception:  # noqa: BLE001
+                        pass
             self._closed = True
 
     def _graph_scene_revision(self) -> tuple[int, int, int]:
@@ -1386,7 +1402,8 @@ class MemoryService:
                 _warn_if_db_empty_with_populated_sibling(physical_db_path)
             except Exception:  # noqa: BLE001 — diagnostics never block startup
                 pass
-        return cls(engine, allowed_workspaces=allowed_workspaces)
+        return cls(engine, allowed_workspaces=allowed_workspaces,
+                   owned_connector=connect)
 
     # ── name → id resolution ───────────────────────────────────────────────────
     def _lookup_workspace(self, name: str) -> Optional[str]:

--- a/engraphis/service.py
+++ b/engraphis/service.py
@@ -1335,7 +1335,8 @@ class MemoryService:
                graph_extractor: Optional[str] = None,
                retention_supervisor: Optional[str] = None,
                allow_automatic_critical_retention: Optional[bool] = None,
-               query_planner=None, read_only: bool = False) -> "MemoryService":
+               query_planner=None, read_only: bool = False,
+               require_exact_backends: bool = False) -> "MemoryService":
         database_path = str(db_path)
         physical_db_path = _physical_database_path(database_path)
         migration_allowed = (
@@ -1378,6 +1379,7 @@ class MemoryService:
             retention_supervisor=retention_supervisor, connect=connect,
             allow_automatic_critical_retention=bool(allow_automatic_critical_retention),
             query_planner=query_planner, read_only=read_only,
+            require_exact_backends=require_exact_backends,
         )
         if migration_allowed:
             try:

--- a/engraphis/service.py
+++ b/engraphis/service.py
@@ -1225,23 +1225,28 @@ class MemoryService:
                     f"{len(alive)} graph index worker(s) did not stop before shutdown"
                 )
 
-            close_engine = getattr(self.engine, "close", None)
-            if callable(close_engine):
-                close_engine()
-            else:
-                self.store.close()
-            # Close the encrypted connector we created (if any) so the SQLCipher
-            # key pragma is cleared from memory. Injected connectors are owned by
-            # the caller and must not be closed here.
-            connector = self._owned_connector
-            if connector is not None:
-                close_conn = getattr(connector, "close", None)
-                if callable(close_conn):
-                    try:
-                        close_conn()
-                    except Exception:  # noqa: BLE001
-                        pass
-            self._closed = True
+            # The owned connector must be closed even when engine shutdown raises
+            # (e.g. a backend cleanup failure). try/finally guarantees the key
+            # pragma is cleared regardless of the engine close path.
+            try:
+                close_engine = getattr(self.engine, "close", None)
+                if callable(close_engine):
+                    close_engine()
+                else:
+                    self.store.close()
+            finally:
+                # Close the encrypted connector we created (if any) so the SQLCipher
+                # key pragma is cleared from memory. Injected connectors are owned
+                # by the caller and must not be closed here.
+                connector = self._owned_connector
+                if connector is not None:
+                    close_conn = getattr(connector, "close", None)
+                    if callable(close_conn):
+                        try:
+                            close_conn()
+                        except Exception:  # noqa: BLE001
+                            pass
+                self._closed = True
 
     def _graph_scene_revision(self) -> tuple[int, int, int]:
         row = self.store.conn.execute("PRAGMA data_version").fetchone()

--- a/integrations/hermes/engraphis/__init__.py
+++ b/integrations/hermes/engraphis/__init__.py
@@ -94,7 +94,10 @@ class EngraphisMemoryProvider(MemoryProvider):
 
     def initialize(self, session_id: str, **kwargs: Any) -> None:
         self._session_id = str(session_id or "")
-        self._open()
+        try:
+            self._open()
+        except Exception as exc:  # noqa: BLE001 - provider must not crash Hermes
+            logger.warning("Engraphis initialize failed (%s)", type(exc).__name__)
 
     def system_prompt_block(self) -> str:
         return (
@@ -243,7 +246,7 @@ class EngraphisMemoryProvider(MemoryProvider):
         try:
             from engraphis.config import settings
             return [settings.db_path]
-        except ImportError:
+        except Exception:  # noqa: BLE001 - best-effort; missing config must not crash
             return []
 
     def shutdown(self) -> None:

--- a/scripts/start_dashboard.py
+++ b/scripts/start_dashboard.py
@@ -192,17 +192,13 @@ def _reuse_or_report_occupied_port(
 
 def _startup_error(exc: BaseException, db: str) -> str:
     if isinstance(exc, ValueError):
-        # Config validation errors should be actionable and not echo sensitive values
-        error_msg = str(exc)
-        if "trusted config" in error_msg or "environment variable" in error_msg.lower():
-            return (
-                f"Configuration error: {error_msg}. "
-                f"Check your config file at {db.rsplit('/', 1)[0]}/.engraphis/config.env "
-                f"and environment variables."
-            )
-        # Unknown ValueError from an optional loader (e.g. AutoTokenizer,
-        # embed-model probe) can embed configured paths or endpoint URLs.
-        # Emit a value-free diagnostic; the operator can run engraphis-init
+        # Any ValueError from dashboard construction can embed configured paths,
+        # model names, or endpoint URLs (e.g. AutoTokenizer.from_pretrained,
+        # embed-model probes, third-party config loaders). Substring heuristics
+        # like "trusted config" are themselves a leak vector: a third-party
+        # library raising ValueError("environment variable failure loading
+        # C:/tenant/private/...") would pass the check. Emit a value-free
+        # diagnostic unconditionally; the operator can run engraphis-init
         # --check for the full detail.
         return (
             f"Configuration error ({type(exc).__name__}). "

--- a/scripts/start_dashboard.py
+++ b/scripts/start_dashboard.py
@@ -191,6 +191,16 @@ def _reuse_or_report_occupied_port(
 
 
 def _startup_error(exc: BaseException, db: str) -> str:
+    if isinstance(exc, ValueError):
+        # Config validation errors should be actionable and not echo sensitive values
+        error_msg = str(exc)
+        if "trusted config" in error_msg or "environment variable" in error_msg.lower():
+            return (
+                f"Configuration error: {error_msg}. "
+                f"Check your config file at {db.rsplit('/', 1)[0]}/.engraphis/config.env "
+                f"and environment variables."
+            )
+        return f"Configuration error: {error_msg}"
     if isinstance(exc, (ImportError, ModuleNotFoundError)):
         return ("The server extra is required: pip install \"engraphis[server]\""
                 " (needs Python 3.10+)")
@@ -209,7 +219,15 @@ def _startup_error(exc: BaseException, db: str) -> str:
             "writable SQLite file, then run engraphis-init --check." % db
         )
     if isinstance(exc, RuntimeError):
-        return str(exc)
+        # RuntimeErrors from factory include backend availability issues
+        error_msg = str(exc)
+        if "require_exact_backends" in error_msg or "unavailable" in error_msg:
+            return (
+                f"Backend initialization failed: {error_msg}. "
+                f"Either install the required dependencies or remove "
+                f"require_exact_backends=True from your configuration."
+            )
+        return error_msg
     return "Dashboard initialization failed. Run engraphis-init --check for diagnostics."
 
 
@@ -218,7 +236,14 @@ def main(argv=None) -> None:
     # a desktop/CLI launch can overwrite trusted embed-model, host, and port
     # values with built-in defaults before dashboard_app is imported, which can turn an
     # offline install or an existing workspace into an apparent startup failure.
-    from engraphis import config as _config  # noqa: F401  # loads trusted config once
+    try:
+        from engraphis import config as _config  # noqa: F401  # loads trusted config once
+        # Validate config eagerly so errors surface before we attempt to bind ports
+        _ = _config.settings
+    except ValueError as exc:
+        sys.exit(f"Error: Configuration validation failed: {exc}\n")
+    except Exception as exc:
+        sys.exit(f"Error: Failed to load configuration: {type(exc).__name__}: {exc}\n")
 
     ap = argparse.ArgumentParser(description="Start the Engraphis WebUI.")
     ap.add_argument("--host", default=os.environ.get("ENGRAPHIS_HOST", "127.0.0.1"),

--- a/scripts/start_dashboard.py
+++ b/scripts/start_dashboard.py
@@ -242,8 +242,14 @@ def main(argv=None) -> None:
         _ = _config.settings
     except ValueError as exc:
         sys.exit(f"Error: Configuration validation failed: {exc}\n")
-    except Exception as exc:
-        sys.exit(f"Error: Failed to load configuration: {type(exc).__name__}: {exc}\n")
+    except Exception as exc:  # noqa: BLE001 - never echo config paths or values
+        # UnsafeStateFile and other OSError subclasses can embed the configured
+        # ENGRAPHIS_ENV_FILE path; emit a value-free diagnostic so tenant-identifying
+        # or secret-bearing paths never reach service logs.
+        sys.exit(
+            f"Error: Failed to load configuration ({type(exc).__name__}). "
+            "Run engraphis-init --check for diagnostics.\n"
+        )
 
     ap = argparse.ArgumentParser(description="Start the Engraphis WebUI.")
     ap.add_argument("--host", default=os.environ.get("ENGRAPHIS_HOST", "127.0.0.1"),

--- a/scripts/start_dashboard.py
+++ b/scripts/start_dashboard.py
@@ -200,7 +200,14 @@ def _startup_error(exc: BaseException, db: str) -> str:
                 f"Check your config file at {db.rsplit('/', 1)[0]}/.engraphis/config.env "
                 f"and environment variables."
             )
-        return f"Configuration error: {error_msg}"
+        # Unknown ValueError from an optional loader (e.g. AutoTokenizer,
+        # embed-model probe) can embed configured paths or endpoint URLs.
+        # Emit a value-free diagnostic; the operator can run engraphis-init
+        # --check for the full detail.
+        return (
+            f"Configuration error ({type(exc).__name__}). "
+            "Run engraphis-init --check for diagnostics."
+        )
     if isinstance(exc, (ImportError, ModuleNotFoundError)):
         return ("The server extra is required: pip install \"engraphis[server]\""
                 " (needs Python 3.10+)")
@@ -227,7 +234,13 @@ def _startup_error(exc: BaseException, db: str) -> str:
                 f"Either install the required dependencies or remove "
                 f"require_exact_backends=True from your configuration."
             )
-        return error_msg
+        # Unknown RuntimeError from a backend or provider can embed proxy
+        # credentials, certificate paths, or endpoint URLs. Redact to the
+        # exception type so operator logs stay value-free.
+        return (
+            f"Backend initialization failed ({type(exc).__name__}). "
+            "Run engraphis-init --check for diagnostics."
+        )
     return "Dashboard initialization failed. Run engraphis-init --check for diagnostics."
 
 

--- a/tests/e2e/ledger.spec.js
+++ b/tests/e2e/ledger.spec.js
@@ -1340,6 +1340,15 @@ test('Graph & Relationships uses the visual explorer controls and applies their 
   await expect(repoFilter).toHaveValue('agent-memory');
   await expect(page.locator('#graph-count')).toContainText('2 of 3 entities · 0 relations');
   await repoFilter.fill('');
+  // Clearing the filter schedules a debounced scene reload (250ms + fetch).
+  // Wait for that request so the DOM reflects the unfiltered scene before
+  // the assertion, rather than racing against the in-flight reload from
+  // the preceding 'Reload data' click.
+  await page.waitForRequest(request => {
+    const url = new URL(request.url());
+    return url.pathname === '/api/graph/scene'
+      && !url.searchParams.get('repo');
+  });
   await expect(page.locator('#graph-count')).toContainText('3 entities · 1 relations');
 
   await page.getByRole('tab', { name: 'Analyse' }).click();

--- a/tests/e2e/ledger.spec.js
+++ b/tests/e2e/ledger.spec.js
@@ -1340,15 +1340,19 @@ test('Graph & Relationships uses the visual explorer controls and applies their 
   await expect(repoFilter).toHaveValue('agent-memory');
   await expect(page.locator('#graph-count')).toContainText('2 of 3 entities · 0 relations');
   await repoFilter.fill('');
-  // Clearing the filter schedules a debounced scene reload (250ms + fetch).
-  // Wait for that request so the DOM reflects the unfiltered scene before
-  // the assertion, rather than racing against the in-flight reload from
-  // the preceding 'Reload data' click.
-  await page.waitForRequest(request => {
+  // Clearing the filter updates the client-side renderer immediately via
+  // setRepoFilter(), but the #graph-count text reflects the last server
+  // scene response. In overview mode without code overlay, the debounced
+  // scheduleGraphRepositoryReload() does not fire, so the count stays at
+  // the previous filtered value. Click Reload data to fetch the unfiltered
+  // scene and wait for the response before asserting.
+  const unfilteredScene = page.waitForRequest(request => {
     const url = new URL(request.url());
     return url.pathname === '/api/graph/scene'
       && !url.searchParams.get('repo');
   });
+  await page.getByRole('button', { name: 'Reload data' }).click();
+  await unfilteredScene;
   await expect(page.locator('#graph-count')).toContainText('3 entities · 1 relations');
 
   await page.getByRole('tab', { name: 'Analyse' }).click();

--- a/tests/test_backends_factories.py
+++ b/tests/test_backends_factories.py
@@ -56,6 +56,35 @@ def test_embedder_factory_falls_back_offline(monkeypatch):
     assert isinstance(get_embedder("definitely-not-a-real-model-xyz", 128), DeterministicEmbedder)
 
 
+def test_embedder_strict_failure_is_redacted_and_not_chained(monkeypatch):
+    import engraphis.backends.embedder_st as embedder_st
+
+    def unavailable(*args, **kwargs):
+        raise RuntimeError("token=super-secret path=C:/private/model")
+
+    monkeypatch.setattr(embedder_st, "SentenceTransformerEmbedder", unavailable)
+    with pytest.raises(RuntimeError) as caught:
+        get_embedder("C:/private/model", 128, require_exact=True)
+
+    assert "super-secret" not in str(caught.value)
+    assert "C:/private/model" not in str(caught.value)
+    assert caught.value.__cause__ is None
+
+
+def test_memory_engine_create_forwards_exact_backend_mode(monkeypatch):
+    import engraphis.core.engine as engine_module
+
+    captured = {}
+
+    def factory(**kwargs):
+        captured.update(kwargs)
+        return "engine"
+
+    monkeypatch.setattr(engine_module, "_ENGINE_FACTORY", factory)
+    assert MemoryEngine.create(require_exact_backends=True) == "engine"
+    assert captured["require_exact_backends"] is True
+
+
 def test_embedder_factory_forwards_an_immutable_model_revision(monkeypatch):
     import engraphis.backends.embedder_st as embedder_st
 

--- a/tests/test_chunking_extractor.py
+++ b/tests/test_chunking_extractor.py
@@ -36,6 +36,27 @@ def test_factory_selects_chunker_and_reads_env(monkeypatch):
     assert ex.target_tokens == 77 and ex.overlap_tokens == 9 and ex.max_chunks == 5
 
 
+@pytest.mark.parametrize("kind", ["llm", "llm_structured"])
+def test_exact_llm_extractor_rejects_missing_credentials(monkeypatch, kind):
+    closed = []
+
+    class FakeLLMClient:
+        api_key = ""
+
+        def close(self):
+            closed.append(True)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "engraphis.llm.client",
+        types.SimpleNamespace(LLMClient=FakeLLMClient),
+    )
+
+    with pytest.raises(RuntimeError, match="ENGRAPHIS_LLM_API_KEY"):
+        get_extractor(kind, require_exact=True)
+    assert closed == [True]
+
+
 def test_factory_loads_explicit_pinned_reader_tokenizer(monkeypatch):
     requests = []
 

--- a/tests/test_chunking_extractor.py
+++ b/tests/test_chunking_extractor.py
@@ -394,3 +394,73 @@ def test_structured_llm_extractor_falls_back_to_chunking_on_failure():
         "mode": "llm_structured",
         "reason": "provider_or_output_error",
     }
+
+
+def test_heading_content_does_not_leak_across_section_boundaries():
+    """Content from one heading section must not appear in another section's chunk."""
+    text = (
+        "# Section Alpha\n\n"
+        "Unique alpha content about apples.\n\n"
+        "# Section Beta\n\n"
+        "Unique beta content about bananas.\n\n"
+        "# Section Gamma\n\n"
+        "Unique gamma content about cherries.\n"
+    )
+    facts = ChunkingExtractor(target_tokens=32, overlap_tokens=0).extract(text)
+    assert len(facts) >= 3
+    for fact in facts:
+        # Each chunk must contain content from only one section.
+        has_alpha = "apples" in fact.content
+        has_beta = "bananas" in fact.content
+        has_gamma = "cherries" in fact.content
+        # At most one section's unique marker per chunk.
+        assert sum([has_alpha, has_beta, has_gamma]) <= 1, (
+            f"chunk leaked across sections: {fact.content!r}"
+        )
+
+
+def test_nested_heading_path_stays_scoped_to_active_section():
+    """A deeper heading must not carry content from a shallower sibling."""
+    text = (
+        "# Top\n\n"
+        "Top level text.\n\n"
+        "## Sub A\n\n"
+        "Sub A unique marker ALPHA.\n\n"
+        "## Sub B\n\n"
+        "Sub B unique marker BETA.\n"
+    )
+    facts = ChunkingExtractor(target_tokens=24, overlap_tokens=0).extract(text)
+    for fact in facts:
+        has_alpha = "ALPHA" in fact.content
+        has_beta = "BETA" in fact.content
+        assert not (has_alpha and has_beta), (
+            f"sibling sections leaked: {fact.content!r}"
+        )
+
+
+def test_code_block_content_does_not_leak_into_surrounding_prose():
+    """A fenced code block's payload must not appear in prose chunks."""
+    text = (
+        "# Intro\n\n"
+        "Prose before the code.\n\n"
+        "```python\n"
+        "UNIQUE_CODE_MARKER_XYZ = 42\n"
+        "```\n\n"
+        "# Outro\n\n"
+        "Prose after the code.\n"
+    )
+    facts = ChunkingExtractor(target_tokens=16, overlap_tokens=0).extract(text)
+    prose_facts = [f for f in facts if "UNIQUE_CODE_MARKER_XYZ" not in f.content]
+    for fact in prose_facts:
+        assert "UNIQUE_CODE_MARKER_XYZ" not in fact.content
+
+
+def test_chunk_metadata_records_token_counter_identity():
+    """Each chunk must record the counter identity for reproducibility."""
+    facts = ChunkingExtractor().extract("Some paragraph text here.")
+    assert len(facts) == 1
+    chunking = facts[0].metadata["chunking"]
+    assert "target_tokens" in chunking
+    assert "overlap_tokens" in chunking
+    assert "token_counter" in chunking
+    assert isinstance(chunking["token_counter"], str)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -74,7 +74,8 @@ def test_cors_wildcard_origin_is_explicitly_accepted():
 def test_cors_schemeless_origins_are_rejected_with_diagnostic():
     """Bare hostnames or dangerous values like ``null`` must be dropped so
     an operator typo cannot open the CORS allow-list to an attacker."""
-    import io, contextlib
+    import contextlib
+    import io
     buf = io.StringIO()
     with contextlib.redirect_stderr(buf):
         result = config._parse_origins("evil.com,null,https://safe.example.com", 8700)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -348,7 +348,7 @@ def test_trusted_env_parser_supports_documented_values_without_interpolation() -
     ],
 )
 def test_trusted_env_parser_rejects_malformed_syntax_without_echoing_values(raw) -> None:
-    with pytest.raises(ValueError, match="trusted config contains invalid syntax") as caught:
+    with pytest.raises(ValueError, match=r"trusted config .* contains invalid syntax") as caught:
         config._parse_trusted_env(raw)
 
     assert "do-not-print" not in str(caught.value)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -403,6 +403,7 @@ def test_trusted_env_parser_rejects_malformed_syntax_without_echoing_values(raw)
         config._parse_trusted_env(raw)
 
     assert "do-not-print" not in str(caught.value)
+    assert str(config._CONFIG_ENV_PATH) not in str(caught.value)
 
 
 def test_explicit_env_file_path_must_be_absolute(tmp_path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -61,6 +61,29 @@ def test_cors_default_origins_follow_configured_port():
     assert config._parse_origins("https://app.example.com", 9000) == [
         "https://app.example.com"]
 
+def test_cors_wildcard_origin_is_explicitly_accepted():
+    """A literal ``*`` must pass through _parse_origins so CORSMiddleware can
+    enable public access.  The dashboard disables credentials when ``*`` is
+    present; this test pins the parser half of that contract."""
+    assert config._parse_origins("*", 8700) == ["*"]
+    # Wildcard mixed with explicit origins: both survive so the operator can
+    # gradually migrate without an all-or-nothing cutover.
+    assert config._parse_origins("*,https://app.example.com", 8700) == [
+        "*", "https://app.example.com"]
+
+def test_cors_schemeless_origins_are_rejected_with_diagnostic():
+    """Bare hostnames or dangerous values like ``null`` must be dropped so
+    an operator typo cannot open the CORS allow-list to an attacker."""
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        result = config._parse_origins("evil.com,null,https://safe.example.com", 8700)
+    assert result == ["https://safe.example.com"]
+    assert "scheme" in buf.getvalue().lower() or "CORS" in buf.getvalue()
+    # Credential-like values must never appear in the diagnostic.
+    assert "evil.com" not in buf.getvalue()
+    assert "null" not in buf.getvalue()
+
 
 def test_cors_origins_use_engraphis_port_env(monkeypatch):
     monkeypatch.delenv("ENGRAPHIS_CORS_ORIGINS", raising=False)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -170,6 +170,40 @@ def test_model_provenance_settings_read_environment_and_are_documented(monkeypat
     assert "ENGRAPHIS_RERANK_REVISION" in (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 
 
+def test_exact_backend_mode_reads_environment_and_is_documented(monkeypatch):
+    monkeypatch.setenv("ENGRAPHIS_REQUIRE_EXACT_BACKENDS", "true")
+
+    configured = Settings()
+
+    assert configured.require_exact_backends is True
+    assert "ENGRAPHIS_REQUIRE_EXACT_BACKENDS" in (REPO_ROOT / ".env.example").read_text(
+        encoding="utf-8"
+    )
+    assert "ENGRAPHIS_REQUIRE_EXACT_BACKENDS" in (REPO_ROOT / "README.md").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_invalid_configuration_warnings_do_not_echo_values(monkeypatch, caplog):
+    secrets = {
+        "ENGRAPHIS_PORT": "port-secret",
+        "ENGRAPHIS_DECAY_HALFLIFE_DAYS": "float-secret",
+        "ENGRAPHIS_LLM_AUTO_EXTRACT": "bool-secret",
+        "ENGRAPHIS_VECTOR_BACKEND": "vector-secret",
+    }
+    for key, value in secrets.items():
+        monkeypatch.setenv(key, value)
+
+    with caplog.at_level("WARNING", logger="engraphis.config"):
+        configured = Settings()
+
+    assert configured.port == 8700
+    assert configured.decay_halflife_days == 7.0
+    assert configured.llm_auto_extract is False
+    assert configured.vector_backend == "numpy"
+    assert all(value not in caplog.text for value in secrets.values())
+
+
 def test_server_vector_backend_defaults_to_safe_auto(monkeypatch):
     monkeypatch.delenv("ENGRAPHIS_VECTOR_BACKEND", raising=False)
     assert Settings().vector_backend == "auto"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -220,6 +220,17 @@ def test_customer_relay_url_is_not_rewritten():
     url = "https://relay.customer.example/team/"
     assert config.canonicalize_relay_url(url) == url.rstrip("/")
 
+
+def test_invalid_relay_url_error_does_not_echo_credentials(monkeypatch):
+    secret_url = "ftp://relay-user:relay-token@example.test"
+    monkeypatch.setenv("ENGRAPHIS_RELAY_URL", secret_url)
+
+    with pytest.raises(ValueError) as caught:
+        Settings()
+
+    assert secret_url not in str(caught.value)
+    assert "relay-token" not in str(caught.value)
+
 def test_invalid_service_mode_exits_process(monkeypatch):
     """Invalid ENGRAPHIS_SERVICE_MODE must fail-closed (sys.exit), not silently fall back."""
     monkeypatch.setenv("ENGRAPHIS_SERVICE_MODE", "bogus")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -231,6 +231,12 @@ def test_invalid_relay_url_error_does_not_echo_credentials(monkeypatch):
     assert secret_url not in str(caught.value)
     assert "relay-token" not in str(caught.value)
 
+
+def test_invalid_cors_origin_diagnostic_does_not_echo_credentials(monkeypatch, capsys):
+    config._parse_origins("ftp://cors-user:cors-token@example.test")
+
+    assert "cors-token" not in capsys.readouterr().err
+
 def test_invalid_service_mode_exits_process(monkeypatch):
     """Invalid ENGRAPHIS_SERVICE_MODE must fail-closed (sys.exit), not silently fall back."""
     monkeypatch.setenv("ENGRAPHIS_SERVICE_MODE", "bogus")

--- a/tests/test_consolidate.py
+++ b/tests/test_consolidate.py
@@ -8,7 +8,7 @@ import pytest
 
 from engraphis.core.consolidate import _cluster_by_subject, consolidate
 from engraphis.core.engine import MemoryEngine
-from engraphis.core.interfaces import MemoryRecord, MemoryType, SearchFilter
+from engraphis.core.interfaces import MemoryRecord, MemoryType, Scope, SearchFilter
 from engraphis.service import MemoryService, ValidationError
 
 
@@ -2304,3 +2304,214 @@ def test_safety_rewrite_clock_is_monotonic_and_rolls_back_with_commit(monkeypatc
     assert rolled_back.modified_hlc == advanced.modified_hlc
     assert rolled_back.metadata == advanced.metadata
     assert rolled_back.provenance == advanced.provenance
+
+
+# ── consolidation audit: working→semantic promotion, decay safety, scope, dry-run ──
+
+def test_working_memories_are_never_promoted_to_semantic_by_consolidation():
+    """Consolidation distills EPISODIC→SEMANTIC only. WORKING memories are transient
+    (archivable) but must never be clustered into a semantic digest — that would be an
+    unintended promotion path outside the explicit promote() API."""
+    eng = MemoryEngine.create(":memory:")
+    wid = eng.store.get_or_create_workspace("w")
+    rid = eng.store.get_or_create_repo(wid, "r")
+    # Create 5 working memories with identical content — enough to form a cluster
+    # if the type filter were wrong.
+    for i in range(5):
+        eng.remember(
+            f"Working task state for batch job {i}",
+            workspace_id=wid, repo_id=rid, mtype=MemoryType.WORKING,
+            resolve_conflicts=False,
+        )
+    report = consolidate(eng, workspace_id=wid, repo_id=rid)
+    # No digests should be created from working memories.
+    assert report["digests_created"] == []
+    assert report["clusters_found"] == 0
+    # All working memories remain live (not archived at default threshold).
+    working = [
+        m for m in eng.store.list_memories(
+            SearchFilter(workspace_id=wid, repo_id=rid),
+        ) if m.mtype == MemoryType.WORKING
+    ]
+    assert len(working) == 5
+    assert all(m.valid_to is None for m in working)
+
+
+def test_recently_accessed_episodic_is_not_prematurely_archived():
+    """Episodic decay uses retention(stability, last_access, now). A recently accessed
+    memory must not be archived even if ingested long ago — the access resets the
+    effective age. This guards against premature deletion of active memories."""
+    eng = MemoryEngine.create(":memory:")
+    wid = eng.store.get_or_create_workspace("w")
+    rid = eng.store.get_or_create_repo(wid, "r")
+    # Ingest an episodic memory 60 days ago with default stability (1 day).
+    ancient = time.time() - 60 * 86400
+    mid = eng.remember(
+        "Important recurring pattern observed in production",
+        workspace_id=wid, repo_id=rid, mtype=MemoryType.EPISODIC,
+        resolve_conflicts=False,
+    )
+    # Backdate ingestion to 60 days ago.
+    eng.store.conn.execute(
+        "UPDATE memories SET ingested_at=?, last_access=? WHERE id=?",
+        (ancient, ancient, mid),
+    )
+    eng.store.conn.commit()
+    # Without recent access, retention would be exp(-60/1) ≈ 0 → archived.
+    # Now simulate a recent access (1 hour ago).
+    recent = time.time() - 3600
+    eng.store.conn.execute(
+        "UPDATE memories SET last_access=? WHERE id=?", (recent, mid),
+    )
+    eng.store.conn.commit()
+    report = consolidate(eng, workspace_id=wid, repo_id=rid, archive_below=0.05)
+    # The memory should NOT be archived because last_access is recent.
+    assert report["archived"] == []
+    mem = eng.store.get_memory(mid)
+    assert mem.valid_to is None
+
+
+def test_stale_unaccessed_episodic_is_archived_at_default_threshold():
+    """An old, unaccessed episodic memory with low stability must be archived when
+    its retention drops below the threshold. This confirms decay works correctly
+    for genuinely forgotten memories."""
+    eng = MemoryEngine.create(":memory:")
+    wid = eng.store.get_or_create_workspace("w")
+    rid = eng.store.get_or_create_repo(wid, "r")
+    ancient = time.time() - 60 * 86400
+    mid = eng.remember(
+        "Transient debug observation from old session",
+        workspace_id=wid, repo_id=rid, mtype=MemoryType.EPISODIC,
+        resolve_conflicts=False,
+    )
+    # Backdate both ingestion and last_access to 60 days ago.
+    eng.store.conn.execute(
+        "UPDATE memories SET ingested_at=?, last_access=? WHERE id=?",
+        (ancient, ancient, mid),
+    )
+    eng.store.conn.commit()
+    report = consolidate(eng, workspace_id=wid, repo_id=rid, archive_below=0.05)
+    assert len(report["archived"]) == 1
+    assert report["archived"][0]["id"] == mid
+    mem = eng.store.get_memory(mid)
+    assert mem.valid_to is not None
+
+
+def test_consolidation_respects_scope_boundaries_no_session_leak():
+    """Session-scoped memories must never appear in a workspace/repo consolidation
+    sweep. MAINTENANCE_SCOPES excludes SESSION; verify this prevents both distillation
+    and archival of session-private state."""
+    eng = MemoryEngine.create(":memory:")
+    wid = eng.store.get_or_create_workspace("w")
+    rid = eng.store.get_or_create_repo(wid, "r")
+    sid = eng.store.start_session(wid, rid)
+    # Create session-scoped episodic memories that would form a cluster.
+    for i in range(5):
+        eng.remember(
+            f"Session private note about task {i}",
+            workspace_id=wid, repo_id=rid, mtype=MemoryType.EPISODIC,
+            scope=Scope.SESSION, session_id=sid,
+            resolve_conflicts=False,
+        )
+    # Also create stale session working memories eligible for archival.
+    ancient = time.time() - 60 * 86400
+    for i in range(3):
+        mid = eng.remember(
+            f"Session temp state {i}",
+            workspace_id=wid, repo_id=rid, mtype=MemoryType.WORKING,
+            scope=Scope.SESSION, session_id=sid,
+            resolve_conflicts=False,
+        )
+        eng.store.conn.execute(
+            "UPDATE memories SET ingested_at=?, last_access=? WHERE id=?",
+            (ancient, ancient, mid),
+        )
+    eng.store.conn.commit()
+    report = consolidate(eng, workspace_id=wid, repo_id=rid, archive_below=0.05)
+    # No digests or archives from session memories.
+    assert report["digests_created"] == []
+    assert report["archived"] == []
+    assert report["clusters_found"] == 0
+
+
+def test_dry_run_produces_zero_database_writes():
+    """dry_run=True must not modify any database state: no new memories, no links,
+    no validity changes, no cursor advances. The report describes what *would* happen."""
+    eng, wid, rid = _engine_with_repeats()
+    # Snapshot pre-state.
+    before_memories = eng.store.conn.execute(
+        "SELECT COUNT(*) FROM memories"
+    ).fetchone()[0]
+    before_links = eng.store.conn.execute(
+        "SELECT COUNT(*) FROM mem_links"
+    ).fetchone()[0]
+    before_changes = eng.store.conn.total_changes
+    report = consolidate(eng, workspace_id=wid, repo_id=rid, dry_run=True)
+    # Report shows what would happen.
+    assert report["dry_run"] is True
+    assert report["digests_created"]
+    assert "would_consolidate" in report["digests_created"][0]
+    # Zero mutations.
+    after_memories = eng.store.conn.execute(
+        "SELECT COUNT(*) FROM memories"
+    ).fetchone()[0]
+    after_links = eng.store.conn.execute(
+        "SELECT COUNT(*) FROM mem_links"
+    ).fetchone()[0]
+    assert after_memories == before_memories
+    assert after_links == before_links
+    assert eng.store.conn.total_changes == before_changes
+
+
+def test_dry_run_does_not_advance_maintenance_cursors():
+    """A dry-run sweep must leave maintenance cursors unchanged so the next real
+    sweep sees the same window."""
+    eng, wid, rid = _engine_with_repeats()
+    from engraphis.core.consolidate import DISTILL_CURSOR_NAME
+    before_cursor = eng.store.get_maintenance_cursor(wid, rid, DISTILL_CURSOR_NAME)
+    consolidate(eng, workspace_id=wid, repo_id=rid, dry_run=True)
+    after_cursor = eng.store.get_maintenance_cursor(wid, rid, DISTILL_CURSOR_NAME)
+    assert after_cursor == before_cursor
+
+
+def test_profiles_dry_run_produces_zero_database_writes():
+    """Profile consolidation dry_run must also be fully read-only."""
+    from engraphis.core.consolidate import consolidate_profiles
+    from engraphis.core.interfaces import Node
+    eng = MemoryEngine.create(":memory:")
+    wid = eng.store.get_or_create_workspace("w")
+    rid = eng.store.get_or_create_repo(wid, "r")
+    eng.store.upsert_entity(Node(
+        id="", name="Aurora", ntype="project", workspace_id=wid, repo_id=rid,
+    ))
+    for i in range(5):
+        eng.remember(
+            f"Aurora milestone {i} completed",
+            workspace_id=wid, repo_id=rid, mtype=MemoryType.EPISODIC,
+            resolve_conflicts=False,
+        )
+    before_memories = eng.store.conn.execute(
+        "SELECT COUNT(*) FROM memories"
+    ).fetchone()[0]
+    before_links = eng.store.conn.execute(
+        "SELECT COUNT(*) FROM mem_links"
+    ).fetchone()[0]
+    before_entities = eng.store.conn.execute(
+        "SELECT COUNT(*) FROM memory_entities"
+    ).fetchone()[0]
+    report = consolidate_profiles(eng, workspace_id=wid, repo_id=rid, dry_run=True)
+    assert report["dry_run"] is True
+    assert report["profiles_created"]
+    assert "would_profile" in report["profiles_created"][0]
+    after_memories = eng.store.conn.execute(
+        "SELECT COUNT(*) FROM memories"
+    ).fetchone()[0]
+    after_links = eng.store.conn.execute(
+        "SELECT COUNT(*) FROM mem_links"
+    ).fetchone()[0]
+    after_entities = eng.store.conn.execute(
+        "SELECT COUNT(*) FROM memory_entities"
+    ).fetchone()[0]
+    assert after_memories == before_memories
+    assert after_links == before_links
+    assert after_entities == before_entities

--- a/tests/test_core_store.py
+++ b/tests/test_core_store.py
@@ -3180,3 +3180,52 @@ def test_context_savings_handles_workspace_ids_above_sqlite_variable_limit(
     assert store.context_savings(workspace_ids=[])["receipt_count"] == 0
     deduped = store.context_savings(workspace_ids=included_ids + included_ids)
     assert deduped["receipt_count"] == len(included_ids)
+
+def test_close_validity_on_nonexistent_memory_is_idempotent_and_audits(store):
+    """Closing a memory that does not exist must not raise; governance audit still records
+    the attempt so MCP forget remains non-idempotent-but-evidenced."""
+    # Must not raise.
+    store.close_validity("mem_does_not_exist", actor="system", reason="test")
+    row = store.conn.execute(
+        "SELECT COUNT(*) AS n FROM audit WHERE target=? AND action='invalidate'",
+        ("mem_does_not_exist",),
+    ).fetchone()
+    assert row["n"] == 1
+
+
+def test_close_validity_twice_keeps_original_close_time_and_re_audits(store, monkeypatch):
+    """A second close must not widen or shift the existing valid_to; it must still
+    append an audit row so repeated governance requests retain evidence."""
+    from engraphis.core import store as store_mod
+    monkeypatch.setattr(store_mod, "now_ts", lambda: 1_000.0)
+    wid = store.get_or_create_workspace("w")
+    mid = store.add_memory(MemoryRecord(id="", content="fact", workspace_id=wid))
+    store.close_validity(mid, at=1_000.0, reason="first")
+    first_close = store.get_memory(mid).valid_to
+    assert first_close == 1_000.0
+
+    monkeypatch.setattr(store_mod, "now_ts", lambda: 2_000.0)
+    store.close_validity(mid, at=2_000.0, reason="second")
+    second_record = store.get_memory(mid)
+    # The earlier close time is preserved; the UPDATE guard prevents widening.
+    assert second_record.valid_to == first_close
+    audits = store.conn.execute(
+        "SELECT COUNT(*) AS n FROM audit WHERE target=? AND action='invalidate'",
+        (mid,),
+    ).fetchone()
+    assert audits["n"] == 2
+
+
+def test_close_validity_at_boundary_equal_to_valid_from_succeeds(store, monkeypatch):
+    """Closing at exactly valid_from is permitted (the interval becomes zero-width);
+    only strictly earlier timestamps are rejected."""
+    from engraphis.core import store as store_mod
+    monkeypatch.setattr(store_mod, "now_ts", lambda: 500.0)
+    wid = store.get_or_create_workspace("w")
+    mid = store.add_memory(MemoryRecord(
+        id="", content="boundary", workspace_id=wid, valid_from=500.0,
+    ))
+    # Equal to valid_from: accepted.
+    store.close_validity(mid, at=500.0)
+    rec = store.get_memory(mid)
+    assert rec.valid_to == 500.0

--- a/tests/test_document_importer.py
+++ b/tests/test_document_importer.py
@@ -514,3 +514,52 @@ def test_secure_erase_removes_document_import_job_items():
         )["files"] == []
     finally:
         service.close()
+
+
+def test_document_import_preserves_source_provenance_in_metadata():
+    """Imported memories must carry raw_sha256, canonical_sha256, and source_mtime_ns."""
+    service = _service()
+    try:
+        workspace_id = service.store.get_or_create_workspace("provenance")
+        mtime = 1_700_000_000_000_000_000
+        raw = b"# Provenance Test\n\nBody content.\n"
+        scan = _scan(("provenance.md", raw))
+        scan.documents[0].source_mtime_ns = mtime
+        importer = DocumentImporter(service)
+        report = importer.import_scan(
+            scan, workspace_id=workspace_id, repo_id=None, session_id=None,
+            scope=Scope.WORKSPACE, memory_type=MemoryType.SEMANTIC,
+            source_label="Provenance test", confirmed=True,
+        )
+        assert report["state"] == "completed"
+        from engraphis.core.interfaces import SearchFilter
+        memories = service.store.list_memories(SearchFilter(workspace_id=workspace_id))
+        assert len(memories) == 1
+        doc_meta = memories[0].metadata.get("document", {})
+        assert doc_meta.get("raw_sha256") == hashlib.sha256(raw).hexdigest()
+        assert doc_meta.get("canonical_sha256")
+        assert doc_meta.get("relative_path") == "provenance.md"
+    finally:
+        service.close()
+
+
+def test_document_import_rejects_oversized_source_gracefully():
+    """A source with rejected files still imports valid documents without crashing."""
+    service = _service()
+    try:
+        workspace_id = service.store.get_or_create_workspace("oversized")
+        small_raw = b"# Small\n\nOK.\n"
+        # Build a scan with one valid document and one rejected entry.
+        scan = _scan(("small.md", small_raw))
+        from engraphis.core.documents import DocumentFileIssue
+        scan.rejected.append(DocumentFileIssue("big.md", "document exceeds safety limit"))
+        importer = DocumentImporter(service)
+        report = importer.import_scan(
+            scan, workspace_id=workspace_id, repo_id=None, session_id=None,
+            scope=Scope.WORKSPACE, memory_type=MemoryType.SEMANTIC,
+            source_label="Mixed sizes", confirmed=True,
+        )
+        assert report["state"] in ("completed", "partial")
+        assert report["counts"]["imported"] == 1
+    finally:
+        service.close()

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -820,3 +820,82 @@ def test_pptx_extraction_falls_back_to_numeric_order_without_presentation():
     record = parse_document(pptx, "plain.pptx")
     assert record.body == "First slide\n\nSecond slide\n\nTenth slide"
     assert record.metadata["slides"] == 3
+
+
+def test_scan_rejects_files_exceeding_tree_byte_limit(monkeypatch, tmp_path):
+    """Cumulative scanned bytes must stop the scan and mark it incomplete."""
+    import engraphis.core.documents as documents_module
+
+    monkeypatch.setattr(documents_module, "MAX_DOCUMENT_TREE_BYTES", 50)
+    for index in range(5):
+        (tmp_path / f"note-{index}.txt").write_text("x" * 20, encoding="utf-8")
+    scan = scan_document_tree(tmp_path)
+    assert scan.complete is False
+    assert any(
+        "250000000 byte safety limit" in issue.reason or "byte safety limit" in issue.reason
+        for issue in scan.rejected
+    )
+
+
+def test_scan_rejects_files_exceeding_file_count_limit(monkeypatch, tmp_path):
+    """Scanning more than MAX_DOCUMENT_FILES must stop and mark incomplete."""
+    import engraphis.core.documents as documents_module
+
+    monkeypatch.setattr(documents_module, "MAX_DOCUMENT_FILES", 3)
+    # Use subdirectories so each directory has ≤ MAX_DOCUMENT_FILES entries,
+    # but the cumulative file count exceeds the limit.
+    for sub in ("a", "b"):
+        (tmp_path / sub).mkdir()
+        for index in range(2):
+            (tmp_path / sub / f"note-{index}.txt").write_text(f"content {index}", encoding="utf-8")
+    scan = scan_document_tree(tmp_path)
+    assert scan.complete is False
+    assert any(
+        "10000 file safety limit" in issue.reason or "file safety limit" in issue.reason
+        for issue in scan.rejected
+    )
+
+
+def test_archive_compression_ratio_is_rejected():
+    """A zip bomb with extreme compression ratio must fail closed."""
+    import io
+    import zipfile
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        # Write a highly compressible payload: 1 byte compressed from 1MB of zeros.
+        zf.writestr("word/document.xml", "\x00" * 1_000_000)
+    raw = buf.getvalue()
+    with pytest.raises(DocumentParseError, match="compression ratio"):
+        parse_document(raw, "bomb.docx")
+
+
+def test_document_record_preserves_source_provenance_fields():
+    """raw_sha256, canonical_sha256, source_size, and source_mtime_ns are always set."""
+    raw = b"# Title\n\nBody text.\n"
+    mtime = 1_700_000_000_000_000_000
+    record = parse_document(raw, "provenance.md", source_mtime_ns=mtime)
+    assert record.raw_sha256 == hashlib.sha256(raw).hexdigest()
+    assert record.canonical_sha256 == hashlib.sha256(record.content.encode("utf-8")).hexdigest()
+    assert record.source_size == len(raw)
+    assert record.source_mtime_ns == mtime
+    assert len(record.raw_sha256) == 64
+    assert len(record.canonical_sha256) == 64
+
+
+def test_adapter_must_return_matching_source_identity():
+    """An adapter that returns mismatched provenance fields is rejected."""
+    raw = b"%PDF-test"
+
+    def bad_identity_adapter(data, path, mtime):
+        text = "extracted"
+        return DocumentRecord(
+            relative_path=path, format="pdf", media_type="application/pdf",
+            title="Report", content=text, body=text,
+            raw_sha256="0" * 64,  # wrong hash
+            canonical_sha256=hashlib.sha256(text.encode()).hexdigest(),
+            source_size=len(data), source_mtime_ns=mtime,
+        )
+
+    with pytest.raises(DocumentParseError, match="invalid source identity"):
+        parse_document(raw, "report.pdf", adapter=bad_identity_adapter)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3071,3 +3071,51 @@ def test_importing_core_engine_does_not_import_concrete_backends():
     )
 
     assert completed.returncode == 0, completed.stderr
+
+
+def test_grounded_recall_empty_query_abstains():
+    """An empty/whitespace-only query has no meaningful support signal and must
+    abstain rather than returning a hallucinated answer from nearest neighbours."""
+    eng = MemoryEngine.create(":memory:")
+    wid = eng.store.get_or_create_workspace("w")
+    eng.remember("Some stored fact about authentication.", workspace_id=wid)
+    for query in ("", "   ", "\t"):
+        answer = eng.grounded_recall(query, workspace_id=wid)
+        assert answer.abstained is True
+        assert answer.grounded is False
+        assert answer.answer == ""
+
+
+def test_grounded_recall_min_support_zero_disables_abstain_gate():
+    """Setting min_support=0 explicitly opts out of the abstain gate: even weak
+    evidence produces an answer (the caller asked for it)."""
+    eng = MemoryEngine.create(":memory:")
+    wid = eng.store.get_or_create_workspace("w")
+    eng.remember("PostgreSQL uses MVCC for concurrency control.", workspace_id=wid)
+    # Query with lexical overlap ("PostgreSQL") but weak semantic relevance;
+    # default floor would abstain, floor=0 produces an answer.
+    answer = eng.grounded_recall("PostgreSQL banana", workspace_id=wid, min_support=0.0)
+    assert answer.abstained is False
+    assert answer.grounded is True
+    assert len(answer.citations) >= 1
+
+
+def test_grounded_recall_no_memories_in_scope_abstains_with_reason():
+    """When the scope contains no memories at all, grounded recall must abstain
+    with a clear reason rather than raising or returning empty citations."""
+    eng = MemoryEngine.create(":memory:")
+    wid = eng.store.get_or_create_workspace("empty-ws")
+    answer = eng.grounded_recall("anything", workspace_id=wid)
+    assert answer.abstained is True
+    assert answer.grounded is False
+    assert "no memory" in answer.reason.lower() or "support" in answer.reason.lower()
+    assert answer.citations == []
+
+
+def test_grounded_recall_invalid_min_support_raises():
+    """Non-finite or out-of-range min_support is a caller error, not a silent default."""
+    eng = MemoryEngine.create(":memory:")
+    wid = eng.store.get_or_create_workspace("w")
+    for bad in (float("nan"), float("inf"), -0.1, 1.5):
+        with pytest.raises(ValueError, match="min_support"):
+            eng.grounded_recall("query", workspace_id=wid, min_support=bad)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1087,3 +1087,90 @@ def test_receipt_tools(monkeypatch):
     assert verified["valid"] is True
     exported = json.loads(srv.engraphis_export_receipts(workspace="acme"))
     assert exported["verification"]["valid"] is True
+
+
+def test_remember_max_length_content_boundary(monkeypatch):
+    """Content at exactly the 100k char limit must succeed; one char over must fail."""
+    srv = _module_with_memory_db(monkeypatch)
+    max_content = "x" * 100_000
+    result = json.loads(srv.engraphis_remember(content=max_content, workspace="acme"))
+    assert result.get("stored") is True
+
+    over = "x" * 100_001
+    err = srv.engraphis_remember(content=over, workspace="acme")
+    assert err.startswith("Error:")
+
+
+def test_recall_empty_query_returns_error(monkeypatch):
+    """Empty or whitespace-only queries violate the min_length=1 constraint."""
+    srv = _module_with_memory_db(monkeypatch)
+    for query in ("", "   "):
+        err = srv.engraphis_recall(query=query, workspace="acme")
+        assert err.startswith("Error:")
+
+
+def test_grounded_recall_empty_query_returns_error_via_mcp(monkeypatch):
+    """A whitespace-only query is stripped to empty by the service layer, producing
+    a validation error rather than a hallucinated answer."""
+    srv = _module_with_memory_db(monkeypatch)
+    srv.engraphis_remember(content="Stored fact.", workspace="acme")
+    err = srv.engraphis_recall_grounded(query="   ", workspace="acme")
+    assert err.startswith("Error:")
+    assert "empty" in err.lower() or "query" in err.lower()
+
+
+def test_remember_invalid_scope_returns_actionable_error(monkeypatch):
+    """An unrecognized scope value must produce an actionable Error: string, not a crash."""
+    srv = _module_with_memory_db(monkeypatch)
+    err = srv.engraphis_remember(
+        content="fact", workspace="acme", scope="galactic",
+    )
+    assert err.startswith("Error:")
+    assert "scope" in err.lower() or "galactic" in err.lower()
+
+
+def test_remember_invalid_mtype_returns_actionable_error(monkeypatch):
+    """An unrecognized memory type must produce an actionable Error: string."""
+    srv = _module_with_memory_db(monkeypatch)
+    err = srv.engraphis_remember(
+        content="fact", workspace="acme", mtype="telepathic",
+    )
+    assert err.startswith("Error:")
+
+
+def test_smart_gateway_classifies_timeout_as_retryable(monkeypatch):
+    """TimeoutError and 'database is locked' exceptions map to E_RETRYABLE."""
+    from engraphis.mcp_server import _classify_gateway_exception
+    timeout_result = _classify_gateway_exception(TimeoutError("connection timed out"))
+    assert timeout_result.isError is True
+    text = timeout_result.content[0].text
+    parsed = json.loads(text)
+    assert parsed["error"]["code"] == "E_RETRYABLE"
+    assert parsed["error"]["retryable"] is True
+
+    locked_result = _classify_gateway_exception(RuntimeError("database is locked"))
+    locked_text = locked_result.content[0].text
+    locked_parsed = json.loads(locked_text)
+    assert locked_parsed["error"]["code"] == "E_RETRYABLE"
+
+
+def test_smart_gateway_classifies_validation_error_as_non_retryable(monkeypatch):
+    """ValidationError maps to E_VALIDATION (or E_NOT_FOUND) and is never retryable."""
+    from engraphis.mcp_server import _classify_gateway_exception
+    from engraphis.service import ValidationError
+    result = _classify_gateway_exception(ValidationError("content must not be empty"))
+    assert result.isError is True
+    parsed = json.loads(result.content[0].text)
+    assert parsed["error"]["code"] == "E_VALIDATION"
+    assert parsed["error"]["retryable"] is False
+    assert "content must not be empty" in parsed["error"]["message"]
+
+
+def test_smart_gateway_unknown_exception_never_leaks_internals(monkeypatch):
+    """Unknown exceptions produce a generic E_INTERNAL message without stack traces."""
+    from engraphis.mcp_server import _classify_gateway_exception
+    result = _classify_gateway_exception(RuntimeError("SECRET_API_KEY=abc123 /home/user/db"))
+    parsed = json.loads(result.content[0].text)
+    assert parsed["error"]["code"] == "E_INTERNAL"
+    assert "SECRET" not in parsed["error"]["message"]
+    assert "/home/user" not in parsed["error"]["message"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -261,6 +261,26 @@ def _module_with_memory_db(monkeypatch):
     return srv
 
 
+def test_lazy_mcp_factory_forwards_exact_backend_mode(monkeypatch):
+    import engraphis.mcp_server as srv
+
+    captured = {}
+
+    class FakeService:
+        pass
+
+    def fake_create(*args, **kwargs):
+        captured.update(kwargs)
+        return FakeService()
+
+    monkeypatch.setattr(srv.MemoryService, "create", fake_create)
+    monkeypatch.setattr(srv, "_service", None)
+    monkeypatch.setattr(srv.settings, "require_exact_backends", True, raising=False)
+
+    assert isinstance(srv.service(), FakeService)
+    assert captured["require_exact_backends"] is True
+
+
 def test_link_symbol_retry_is_stable_and_truthfully_idempotent(monkeypatch):
     import asyncio
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -165,6 +165,7 @@ def test_response_budget_ignores_unbounded_citation_numbers():
 def test_http_cli_matches_dns_rebinding_guard_to_selected_loopback(
         monkeypatch, host, host_header, origin, classic):
     import asyncio
+    import types
     from types import SimpleNamespace
 
     from mcp.server.transport_security import TransportSecurityMiddleware
@@ -186,7 +187,13 @@ def test_http_cli_matches_dns_rebinding_guard_to_selected_loopback(
 
     smart_server = server()
     classic_server = server()
-    fake_module = SimpleNamespace(mcp=smart_server, classic_mcp=classic_server, _eager_exact_backend_check=lambda: None)
+    # Use a real ModuleType so ``from engraphis.mcp_server import X`` works
+    # across Python 3.10-3.14; SimpleNamespace lacks __spec__/__loader__ and
+    # the import machinery rejects it on some versions.
+    fake_module = types.ModuleType("engraphis.mcp_server")
+    fake_module.mcp = smart_server
+    fake_module.classic_mcp = classic_server
+    fake_module._eager_exact_backend_check = lambda: None
     monkeypatch.setitem(sys.modules, "engraphis.mcp_server", fake_module)
     monkeypatch.setattr(mcp_http_cli, "_dependency_error", lambda: "")
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -186,7 +186,7 @@ def test_http_cli_matches_dns_rebinding_guard_to_selected_loopback(
 
     smart_server = server()
     classic_server = server()
-    fake_module = SimpleNamespace(mcp=smart_server, classic_mcp=classic_server)
+    fake_module = SimpleNamespace(mcp=smart_server, classic_mcp=classic_server, _eager_exact_backend_check=lambda: None)
     monkeypatch.setitem(sys.modules, "engraphis.mcp_server", fake_module)
     monkeypatch.setattr(mcp_http_cli, "_dependency_error", lambda: "")
 

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,4 +1,6 @@
 import pytest
+import sys
+import types
 
 from engraphis.backends.retention import LLMRetentionSupervisor, get_retention_supervisor
 from engraphis.core.engine import MemoryEngine
@@ -179,3 +181,23 @@ def test_llm_supervisor_rejects_non_finite_or_wrongly_typed_output():
 def test_unknown_retention_backend_is_actionable():
     with pytest.raises(ValueError, match="none.*llm"):
         get_retention_supervisor("mystery")
+
+
+def test_exact_llm_retention_requires_credentials(monkeypatch):
+    closed = []
+
+    class FakeLLMClient:
+        api_key = ""
+
+        def close(self):
+            closed.append(True)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "engraphis.llm.client",
+        types.SimpleNamespace(LLMClient=FakeLLMClient),
+    )
+
+    with pytest.raises(RuntimeError, match="ENGRAPHIS_LLM_API_KEY"):
+        get_retention_supervisor("llm", require_exact=True)
+    assert closed == [True]

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -8,6 +8,7 @@ why/timeline/proactive tools.
 import sqlite3
 import threading
 import time
+from types import SimpleNamespace
 import numpy as np
 import pytest
 
@@ -61,6 +62,23 @@ class _ReviewedLocalService:
 
 def _svc() -> _ReviewedLocalService:
     return _ReviewedLocalService(MemoryService.create(":memory:"))
+
+
+def test_service_create_forwards_exact_backend_mode(monkeypatch):
+    captured = {}
+    store = SimpleNamespace(allowed_workspaces=None)
+
+    def fake_create(cls, db_path, **kwargs):
+        captured.update(db_path=db_path, **kwargs)
+        return SimpleNamespace(store=store)
+
+    monkeypatch.setattr(service_module.MemoryEngine, "create", classmethod(fake_create))
+    MemoryService.create(
+        ":memory:", extractor="none", graph_extractor="none",
+        retention_supervisor="none", require_exact_backends=True,
+    )
+
+    assert captured["require_exact_backends"] is True
 
 
 def test_empty_configured_db_warns_about_populated_owner_db(tmp_path, monkeypatch, capsys):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3388,3 +3388,127 @@ def test_local_equal_hlc_conflict_provenance_converges_across_peers():
     assert fresh_conflict is not None
     assert fresh_conflict.provenance["source"] == "sync_conflict"
     assert fresh_conflict.provenance["conflict_of"] == "same-local-id"
+
+
+
+# ── relay push retry on transient failures ────────────────────────────────────
+
+def test_relay_push_retries_transient_502_and_succeeds(monkeypatch):
+    """A 502 on push is retried with backoff; a later success completes the round."""
+    from engraphis.backends.sync_relay import (
+        RelayTransport,
+    )
+
+    calls = {"count": 0}
+
+    def fake_urlopen(req, *, timeout):
+        calls["count"] += 1
+        if calls["count"] <= 1:
+            import urllib.error
+            import io
+            raise urllib.error.HTTPError(
+                req.full_url, 502, "Bad Gateway", {}, io.BytesIO(b""),
+            )
+        # Second call succeeds.
+        class _Resp:
+            def __enter__(self_inner):
+                return self_inner
+            def __exit__(self_inner, *a):
+                pass
+            def read(self_inner, n):
+                return b"ok"
+        return _Resp()
+
+    monkeypatch.setattr(
+        "engraphis.backends.sync_relay._urlopen_no_redirect", fake_urlopen,
+    )
+    monkeypatch.setattr("time.sleep", lambda s: None)  # skip real delays
+
+    transport = RelayTransport(
+        "https://relay.example.test", "ws", access_token="tok_" + "x" * 24,
+    )
+    transport.push("bundle-dev_a.json", b"payload")
+    assert calls["count"] == 2  # first 502 + one retry
+
+
+def test_relay_push_does_not_retry_fatal_401(monkeypatch):
+    """A 401 is a permanent refusal — retrying only amplifies the denial."""
+    import urllib.error
+    import io
+    from engraphis.backends.sync_relay import RelayTransport, RelayError
+
+    calls = {"count": 0}
+
+    def fake_urlopen(req, *, timeout):
+        calls["count"] += 1
+        raise urllib.error.HTTPError(
+            req.full_url, 401, "Unauthorized", {}, io.BytesIO(b""),
+        )
+
+    monkeypatch.setattr(
+        "engraphis.backends.sync_relay._urlopen_no_redirect", fake_urlopen,
+    )
+
+    transport = RelayTransport(
+        "https://relay.example.test", "ws", access_token="tok_" + "x" * 24,
+    )
+    with pytest.raises(RelayError, match="HTTP 401"):
+        transport.push("bundle-dev_a.json", b"payload")
+    assert calls["count"] == 1  # no retry
+
+
+def test_relay_get_does_not_retry_transient_errors(monkeypatch):
+    """Pull (GET) must not retry — per-bundle isolation handles partial failures."""
+    import urllib.error
+    import io
+    from engraphis.backends.sync_relay import RelayTransport, RelayError
+
+    calls = {"count": 0}
+
+    def fake_urlopen(req, *, timeout):
+        calls["count"] += 1
+        raise urllib.error.HTTPError(
+            req.full_url, 503, "Service Unavailable", {}, io.BytesIO(b""),
+        )
+
+    monkeypatch.setattr(
+        "engraphis.backends.sync_relay._urlopen_no_redirect", fake_urlopen,
+    )
+
+    transport = RelayTransport(
+        "https://relay.example.test", "ws", access_token="tok_" + "x" * 24,
+    )
+    with pytest.raises(RelayError, match="HTTP 503"):
+        transport.list_names()  # GET request
+    assert calls["count"] == 1  # no retry for GET
+
+
+def test_relay_push_exhausts_retries_and_raises(monkeypatch):
+    """After MAX_PUSH_RETRIES transient failures, the last error is raised."""
+    import urllib.error
+    import io
+    from engraphis.backends.sync_relay import (
+        RelayTransport,
+        RelayError,
+        MAX_PUSH_RETRIES,
+    )
+
+    calls = {"count": 0}
+
+    def fake_urlopen(req, *, timeout):
+        calls["count"] += 1
+        raise urllib.error.HTTPError(
+            req.full_url, 503, "Service Unavailable", {}, io.BytesIO(b""),
+        )
+
+    monkeypatch.setattr(
+        "engraphis.backends.sync_relay._urlopen_no_redirect", fake_urlopen,
+    )
+    monkeypatch.setattr("time.sleep", lambda s: None)
+
+    transport = RelayTransport(
+        "https://relay.example.test", "ws", access_token="tok_" + "x" * 24,
+    )
+    with pytest.raises(RelayError, match="HTTP 503"):
+        transport.push("bundle-dev_a.json", b"payload")
+    assert calls["count"] == 1 + MAX_PUSH_RETRIES


### PR DESCRIPTION
## Summary

- Add strict opt-in backend loading while preserving existing fallback defaults.
- Harden encrypted database/config/startup/Docker/health handling.
- Bound sync-relay retries and update the sync interface.
- Consolidate reliability fixes across extraction, consolidation, documents, engine, store, MCP, and sync paths with regression coverage.

## Validation

- `ruff check .`
- `pyright`
- `python -m pytest tests/ -q`
- commercial manifest and dashboard asset checks
- retrieval, reinforcement, adversarial, and ablation evaluation gates
- `python -m pytest tests/test_release_evidence.py -q`
- package wheel build and isolated no-dependency install

## Scope

This PR is based on `origin/main` and intentionally excludes the Galaxy/UI PR files, generated `uv.lock`, evaluation-integrity/profile helpers, the unreferenced Windows subprocess helper, and stale detached-worktree changes. Package metadata remains at version `1.6`; no tag or release is created here.