### PR TITLE
docs: remove advertising proof gallery and campaign guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,7 +133,8 @@ uv.lock
 /venv_status.txt
 /r3.txt
 
-# Local Command Code session-transcript analysis prompts — inspect private
-# ~/.commandcode/ session data, never commit these.
-/pROMPT_SESSION_TRANSCRIPT_ANALYSIS.md
-/session_transcript_query_prompt.md
+# Local Command Code session-transcript analysis prompts - inspect private
+# ~/.commandcode/ session data, never commit these. Character classes keep
+# mixed-case variants from slipping through on case-insensitive machines.
+/[Pp][Rr][Oo][Mm][Pp][Tt]_[Ss][Ee][Ss][Ss][Ii][Oo][Nn]_[Tt][Rr][Aa][Nn][Ss][Cc][Rr][Ii][Pp][Tt]_[Aa][Nn][Aa][Ll][Yy][Ss][Ii][Ss].md
+/[Ss][Ee][Ss][Ss][Ii][Oo][Nn]_[Tt][Rr][Aa][Nn][Ss][Cc][Rr][Ii][Pp][Tt]_[Qq][Uu][Ee][Rr][Yy]_[Pp][Rr][Oo][Mm][Pp][Tt].md


### PR DESCRIPTION
## Summary

Removes the retired advertising surfaces from the repository:

- Deletes `docs/advertising/` (`index.html`, `campaign.md`) and its dedicated test `tests/test_advertising_assets.py`
- Removes the "Grounded, not guessed" proof-gallery tagline and its two links from the README
- Adds `.gitignore` rules for two local session-transcript prompt filenames that inspect private `~/.commandcode/` session data, using the repo's existing character-class casing convention for private working papers

## Verification

- `pytest tests/test_benchmark_evidence.py tests/test_release_infrastructure.py tests/test_dashboard_vendor_assets.py tests/test_skill_package.py -q` — 64 passed (includes the em-dash punctuation contract and registered benchmark-string gates flagged during review)
- `ruff check .` — clean
- README rebuilt from pristine upstream content with only the tagline removed; verified no BOM, no encoding drift, all arrows/checkmarks/tree glyphs intact
