### PR TITLE
test(conftest): force ENGRAPHIS_EXTRACTOR=none for the offline gate

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,12 +12,13 @@ if str(ROOT) not in sys.path:
 # explicitly via monkeypatch (see tests/test_update_check.py).
 os.environ.setdefault("ENGRAPHIS_UPDATE_CHECK", "0")
 
-# Owner machines may configure ENGRAPHIS_EXTRACTOR=llm (via ~/.engraphis/config.env),
-# which would make every ingest-path test block on live LLM extraction calls. The unit
-# suite is offline-inert by contract (AGENTS.md §1 "primary offline gate"); tests that
-# exercise extraction opt back in explicitly via monkeypatch.setenv. setdefault keeps a
-# real shell override working, matching how config.env itself defers to the environment.
-os.environ.setdefault("ENGRAPHIS_EXTRACTOR", "none")
+# Owner machines may configure ENGRAPHIS_EXTRACTOR=llm_structured (via ~/.engraphis/config.env
+# or an exported shell variable), which would make every ingest-path test block on live LLM
+# extraction calls — and under tests/conftest.py's DNS stub they hang instead of failing
+# fast. The unit suite is offline-inert by contract (AGENTS.md §1 "primary offline gate");
+# tests that exercise extraction opt back in explicitly via monkeypatch.setenv, so this is
+# forced rather than setdefault: no shell export can leak a live LLM into the gate.
+os.environ["ENGRAPHIS_EXTRACTOR"] = "none"
 
 # The legacy scripts/test_*.py files are HTTP smoke tests (need a running server +
 # httpx), not unit tests. Keep pytest focused on the tests/ suite.


### PR DESCRIPTION
## Summary

Single cherry-picked commit (originally `7503e2e` on a local branch): the root `conftest.py` offline gate now **forces** `ENGRAPHIS_EXTRACTOR=none` instead of using `setdefault`.

**Why:** `setdefault` deferred to any exported shell variable, so an owner machine exporting e.g. `ENGRAPHIS_EXTRACTOR=llm_structured` leaked a live LLM extractor into every ingest-path test. Under `tests/conftest.py`'s DNS stub, extraction calls hang rather than fail fast — deterministically timing out `test_session_close_linearizes_before_delayed_memory_write[ingest]`. Tests that exercise extraction already opt back in explicitly via `monkeypatch.setenv`, so nothing legitimate is lost.

## Verification

- Hostile-environment proof: with `ENGRAPHIS_EXTRACTOR=llm_structured` exported, the previously flaky test passes deterministically
- `pytest tests/test_session_idempotent.py tests/test_cloud_features.py -q` — 70 passed
- Full-suite collection clean; `ruff check .` clean
