### PR TITLE
fix(ci): allow the system temp dir in release-gate index roots

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,10 +65,10 @@ jobs:
           ruff check .
           pyright
           python -c "import fastapi, httpx, mcp, multipart, pydantic, uvicorn"
-          ENGRAPHIS_INDEX_ROOTS="${GITHUB_WORKSPACE}:${RUNNER_TEMP}" python -m pytest -o addopts="" tests/ -q -rs --basetemp="${RUNNER_TEMP}/engraphis-pytest"
-          ENGRAPHIS_INDEX_ROOTS="${GITHUB_WORKSPACE}:${RUNNER_TEMP}" python -m pytest -o addopts="" tests/test_public_research_boundary.py -q --basetemp="${RUNNER_TEMP}/engraphis-pytest"
-          ENGRAPHIS_INDEX_ROOTS="${GITHUB_WORKSPACE}:${RUNNER_TEMP}" python -m pytest -o addopts="" tests/test_compact_recall.py tests/test_eval_performance.py -q --basetemp="${RUNNER_TEMP}/engraphis-pytest"
-          ENGRAPHIS_INDEX_ROOTS="${GITHUB_WORKSPACE}:${RUNNER_TEMP}" python -m pytest -o addopts="" tests/test_eval_harness.py tests/test_benchmark_evidence.py -q --basetemp="${RUNNER_TEMP}/engraphis-pytest"
+          ENGRAPHIS_INDEX_ROOTS="${GITHUB_WORKSPACE}:${RUNNER_TEMP}:$(python -c 'import tempfile; print(tempfile.gettempdir())')" python -m pytest -o addopts="" tests/ -q -rs --basetemp="${RUNNER_TEMP}/engraphis-pytest"
+          ENGRAPHIS_INDEX_ROOTS="${GITHUB_WORKSPACE}:${RUNNER_TEMP}:$(python -c 'import tempfile; print(tempfile.gettempdir())')" python -m pytest -o addopts="" tests/test_public_research_boundary.py -q --basetemp="${RUNNER_TEMP}/engraphis-pytest"
+          ENGRAPHIS_INDEX_ROOTS="${GITHUB_WORKSPACE}:${RUNNER_TEMP}:$(python -c 'import tempfile; print(tempfile.gettempdir())')" python -m pytest -o addopts="" tests/test_compact_recall.py tests/test_eval_performance.py -q --basetemp="${RUNNER_TEMP}/engraphis-pytest"
+          ENGRAPHIS_INDEX_ROOTS="${GITHUB_WORKSPACE}:${RUNNER_TEMP}:$(python -c 'import tempfile; print(tempfile.gettempdir())')" python -m pytest -o addopts="" tests/test_eval_harness.py tests/test_benchmark_evidence.py -q --basetemp="${RUNNER_TEMP}/engraphis-pytest"
           python -m eval.harness --dataset eval/datasets/sample.jsonl --k 5
           python -m eval.harness --dataset eval/datasets/codemem.jsonl --k 5
           python -m eval.ablation
@@ -306,7 +306,7 @@ jobs:
           if [ "${{ matrix.python-version }}" != "3.9" ]; then
             python -c "import fastapi, httpx, mcp, multipart, pydantic, uvicorn"
           fi
-          ENGRAPHIS_INDEX_ROOTS="${GITHUB_WORKSPACE}:${RUNNER_TEMP}" python -m pytest -o addopts="" tests/ -q -rs --basetemp="${RUNNER_TEMP}/engraphis-pytest"
+          ENGRAPHIS_INDEX_ROOTS="${GITHUB_WORKSPACE}:${RUNNER_TEMP}:$(python -c 'import tempfile; print(tempfile.gettempdir())')" python -m pytest -o addopts="" tests/ -q -rs --basetemp="${RUNNER_TEMP}/engraphis-pytest"
           python -m eval.harness --dataset eval/datasets/sample.jsonl --k 5
           python -m eval.harness --dataset eval/datasets/codemem.jsonl --k 5
           python -m eval.ablation


### PR DESCRIPTION
fix(ci): allow the system temp dir in release-gate index roots

The release workflow's ENGRAPHIS_INDEX_ROOTS omitted tempfile.gettempdir(),
which ci.yml has included since #159. Two suites seed fixtures under the
system temp dir and call index_repo against them:
- eval/code_arm.py (via test_eval_code_arm.py)
- tests/test_documents.py XML/container attack fixtures

Both failed on every Python leg of the v1.6 release run (run 32852978103),
blocking the PyPI publish. Same root cause silently blocked the Aug 15
v1.7/v1.6.1 tag runs. Ported the third approved root to all five pytest
invocations that run the full suite or fixture-dependent modules; the
encryption job keeps the narrower two-root set, matching ci.yml.

Co-authored-by: CommandCodeBot <noreply@commandcode.ai>
