### PR TITLE
fix: respect nonadditive token counters, finer importance steps, galaxy live-limit guard

### DIFF
--- a/engraphis/core/context.py
+++ b/engraphis/core/context.py
@@ -115,8 +115,8 @@ class DeterministicContextPacker:
             excerpt = ""
             truncated = False
             reason = ""
-            if self._count(base) < budget:
-                available = budget - self._count(base)
+            available = max(0, budget - self._count(base))
+            if available:
                 excerpt, truncated, reason = self._excerpt(
                     query, candidate, available
                 )

--- a/engraphis/dashboard_assets/index.html
+++ b/engraphis/dashboard_assets/index.html
@@ -221,7 +221,7 @@
                 <label>Type<select id="editor-memory-type"><option>working</option><option>episodic</option><option selected>semantic</option><option>procedural</option></select></label>
                 <label>Content<textarea id="editor-memory-content" rows="12" maxlength="10000" required placeholder="A discrete, durable fact or procedure…"></textarea></label>
                 <p id="editor-error" class="form-error" role="alert" hidden></p>
-                <label for="editor-memory-importance">Importance<input id="editor-memory-importance" type="range" min="0" max="1" step="0.05" value="0.5" aria-label="Memory importance"></label>
+                <label for="editor-memory-importance">Importance<input id="editor-memory-importance" type="range" min="0" max="1" step="0.025" value="0.5" aria-label="Memory importance"></label>
                 <div class="form-actions">
                   <button id="editor-cancel" class="secondary-button" type="button">Cancel</button>
                   <button class="primary-button" type="submit">Save memory</button>

--- a/engraphis/dashboard_assets/ledger.js
+++ b/engraphis/dashboard_assets/ledger.js
@@ -3388,8 +3388,12 @@
         oldHost.insertAdjacentElement('afterend', candidateHost);
         /* Authored-Galaxy detection must key off scene markers, not the toolbar preset:
            entering Every via its chip sets the preset to 'every', but a complete scene
-           with system anchors still needs the hierarchical orbit engine and overlay. */
-        const galaxyQuality = fullGraph
+           with system anchors still needs the hierarchical orbit engine and overlay.
+           The live-limit guard keeps very large complete scenes on the lightweight
+           Every renderer instead of the full physics galaxy. */
+        const galaxyWithinLiveLimit = data.nodes.length <= GRAPH_INITIAL_NODE_LIMIT
+          && data.links.length <= GRAPH_INITIAL_EDGE_LIMIT;
+        const galaxyQuality = fullGraph && galaxyWithinLiveLimit
           && data.nodes.some(node => node.anchor_role === 'community'
             && (node.system_anchor_id !== undefined
               || Number.isFinite(Number(node.galactic_radius))));

--- a/tests/test_context_packing.py
+++ b/tests/test_context_packing.py
@@ -147,6 +147,32 @@ def test_nonduplicate_title_remains_in_the_citation_header() -> None:
     assert chunks[0].excerpt == "Deploy only after signed checks."
 
 
+def test_compact_header_respects_nonadditive_counter_budget() -> None:
+    class HeaderOverheadCounter:
+        identity = "test.header-overhead"
+
+        def __call__(self, text: str) -> int:
+            count = len(text.split())
+            if text.startswith("[1]") and len(text) > 4:
+                count += 3 if text.splitlines()[0] != "[1]" else (
+                    1 if text == "[1]\nAlpha rest" else 0
+                )
+            return count
+
+    packer = DeterministicContextPacker(HeaderOverheadCounter())
+    candidate = _candidate(
+        "mem_compact_header",
+        "Alpha rest",
+        title="Alpha",
+    )
+
+    context, chunks, usage = packer.pack("alpha", [candidate], token_budget=3)
+
+    assert context.startswith("[1]\nAlpha")
+    assert chunks[0].excerpt.startswith("Alpha")
+    assert usage.context_tokens <= usage.budget_tokens == 3
+
+
 def test_sentence_excerpt_marks_omission_and_preserves_qualifying_evidence() -> None:
     packer = DeterministicContextPacker()
     candidate = _candidate(

--- a/tests/test_dashboard_v2.py
+++ b/tests/test_dashboard_v2.py
@@ -914,6 +914,7 @@ def test_graph_motion_saved_views_and_tuning_controls_are_wired(monkeypatch, tmp
             assert behavior in script.text
         assert "syncGraphSpacetimeTuning(" in script.text
         assert "state.graphSpacetimeOverlay.setEnabled(graphIsGalaxy())" in script.text
+        assert 'id="editor-memory-importance" type="range" min="0" max="1" step="0.025"' in page.text
 
 
 def test_code_overlay_scopes_only_to_known_repositories(monkeypatch, tmp_path):
@@ -940,6 +941,7 @@ def test_all_nodes_mode_preserves_scope_preferences_and_bounds_heavy_work(monkey
         assert "if (loadAll) {" in script.text
         assert "return Promise.all([ensureGraphAllAsset(), ensureGraphAssets(false)]);" in script.text
         assert "const graphFactory = galaxyQuality ? window.EngraphisGraph" in script.text
+        assert "const galaxyWithinLiveLimit = data.nodes.length <= GRAPH_INITIAL_NODE_LIMIT" in script.text
         assert "scopeControl.disabled = full" not in script.text
         assert "graph.setCollapse(byId('graph-collapse').checked ? 'auto' : false)" in script.text
         assert "const includeCode = targetIncludeCode ? '&include_code=true' : '';" in script.text

--- a/tests/test_graph_every_asset.py
+++ b/tests/test_graph_every_asset.py
@@ -420,7 +420,8 @@ def test_ledger_routes_the_every_layout_and_restores_filters() -> None:
 
 def test_ledger_keeps_authored_galaxy_scenes_on_the_hierarchical_engine() -> None:
     ledger = LEDGER.read_text(encoding="utf-8")
-    assert "const galaxyQuality = fullGraph\n          && data.nodes.some" in ledger
+    assert "const galaxyQuality = fullGraph && galaxyWithinLiveLimit\n          && data.nodes.some" in ledger
+    assert "const galaxyWithinLiveLimit = data.nodes.length <= GRAPH_INITIAL_NODE_LIMIT" in ledger
     assert "candidateOverlay.setEnabled(galaxyQuality || graphIsGalaxy())" in ledger
     # The Every-node chip changes the toolbar preset before the complete scene arrives. Both
     # candidates must therefore be preloaded so a fast entry cannot select a missing Galaxy


### PR DESCRIPTION
Three small fixes salvaged from local review-worktree iteration (uncommitted work in the w153 orca worktree), re-based onto main's current transactional graph pipeline: