### PR TITLE
fix(scripts): drop unused HOOK_KEY constant from install_cc_hook.py

### DIFF
--- a/scripts/install_cc_hook.py
+++ b/scripts/install_cc_hook.py
@@ -20,7 +20,6 @@ from pathlib import Path
 SETTINGS_PATH = Path(os.environ.get("COMMANDCODE_SETTINGS_PATH")
                      or Path.home() / ".commandcode" / "settings.json")
 HOOK_PATH = Path(__file__).resolve().parent.parent / "integrations" / "commandcode" / "session_start_hook.py"
-HOOK_KEY = "cc-engraphis-session-start"
 
 
 def _utc_stamp() -> str:


### PR DESCRIPTION
Follow-up to #171. Review pass 2 found one dead identifier in the freshly
added `scripts/install_cc_hook.py`: the `HOOK_KEY = "cc-engraphis-session-start"`
constant declared at the top of the module is never referenced anywhere.
The idempotency check in `install()` / `uninstall()` matches on the
`command` string instead. This PR drops the dead identifier so a
reviewer of #171 doesn't have to flag it.

One file, one line removed, all 131 PR1 + hook installer + smart-gateway
tests still pass (`tests/test_session_start_hook.py`,
`tests/test_smart_mcp_gateway.py`, `tests/test_mcp_server.py`).

Reviewer suggestion source: PR #171 review pass 2 (commit 725bb6e on top
of 4ec6291).
