### PR TITLE
docs(changelog): soften resolver + smart-binding prose per security-disclosure standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,11 @@ All notable changes to Engraphis are documented here. Format loosely follows
   / `ENGRAPHIS_RERANK_MODEL`). Evaluated offline on the bundled retrieval gates
   (sample.jsonl, codemem.jsonl, k=5): hit@5 stays at 1.0 with zero per-question
   regressions, MRR@5 lifts 0.889 -> 0.944 (sample) and 0.962 -> 0.981 (codemem),
-  with ~15 ms per query added. Not the default; flip with a one-line config
-  (`ENGRAPHIS_RERANK_MODEL` in `.env`, then restart the MCP server and dashboard).
+  with ~15 ms per query added. Not the default; set the value in the trusted
+  config file (`~/.engraphis/config.env` on the operator account, or as a
+  process environment variable) — Engraphis deliberately does not read the
+  CWD `.env`, so editing `./.env` and restarting leaves the identity
+  reranker active. Restart the MCP server and dashboard after the change.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,8 @@ All notable changes to Engraphis are documented here. Format loosely follows
   (savings_ratio 0.0 -> 0.4975) with no caller-side arguments. The packer is the
   existing 1.6 contract; the change just makes it the default fast path.
 - Smart MCP `engraphis_remember` now accepts and forwards `subject_key` and
-  `claim_kind` to the classic tool. Without this, every keyed write silently stored
-  empty keys because the served gateway surface dropped the parameters; the
-  documented safe-supersession mechanism is now reachable through MCP.
+  `claim_kind` to the classic tool, so the documented safe-supersession
+  mechanism is reachable through MCP.
 - A new integration at `integrations/commandcode/session_start_hook.py` (with
   `scripts/install_cc_hook.py` for idempotent user-scope install/uninstall) wires
   durable-memory recall into Command Code's SessionStart lifecycle: each new
@@ -27,21 +26,20 @@ All notable changes to Engraphis are documented here. Format loosely follows
   / `ENGRAPHIS_RERANK_MODEL`). Evaluated offline on the bundled retrieval gates
   (sample.jsonl, codemem.jsonl, k=5): hit@5 stays at 1.0 with zero per-question
   regressions, MRR@5 lifts 0.889 -> 0.944 (sample) and 0.962 -> 0.981 (codemem),
-  with ~15 ms per query added. Not the default; flip with a one-line config.
+  with ~15 ms per query added. Not the default; flip with a one-line config
+  (`ENGRAPHIS_RERANK_MODEL` in `.env`, then restart the MCP server and dashboard).
 
 ### Changed
 
 - The reworded-correction detector in `core/resolve.py` now supersedes reworded
-  corrections without a stable `subject_key` when the aligned token diff shows
-  a same-attribute value change (e.g. "the timeout is 30 seconds" -> "we raised
-  the timeout to 90 seconds"). Measured on a 36-pair labeled corpus: 35/36
-  positives superseded with the real embedder and 0/36 false invalidations
-  (was 1/5 on the unkeyed benchmark pairs). Vetoes preserve coexisting
-  distinct facts: clashing environment qualifiers (staging vs production),
-  named mixed-case identifier swaps (ProviderA -> ProviderB), clean noun-for-noun
-  replacements (REST -> GraphQL docs), and pairs with fewer than two shared
-  subject tokens. The strong-evidence branch now also honours the env-conflict
-  veto (R1 follow-up fix).
+  corrections on a same-attribute token-diff signal (e.g. "the timeout is
+  30 seconds" -> "we raised the timeout to 90 seconds"). Measured on a
+  36-pair labeled corpus: 35/36 positives superseded with the real embedder
+  and 0/36 false invalidations. Vetoes preserve coexisting distinct facts:
+  clashing environment qualifiers (staging vs production), named mixed-case
+  identifier swaps (ProviderA -> ProviderB), clean noun-for-noun replacements
+  (REST -> GraphQL docs), and pairs with fewer than two shared subject tokens.
+  The strong-evidence branch now also honours the env-conflict veto.
 - The `temporal_splice` flag passed from `core/engine.py` to `resolve()` is
   now narrowed to the bi-temporal backfill case (a deliberate `valid_at`
   AND a `subject_key`), instead of any `valid_at`-pinned write. Scheduled
@@ -49,10 +47,8 @@ All notable changes to Engraphis are documented here. Format loosely follows
 
 ### Fixed
 
-- The Smart MCP gateway `engraphis_remember` binding was silently dropping
-  `subject_key` and `claim_kind`; this is the underlying cause of the
-  benchmark correction-miss pattern that the reworded-correction detector
-  then had to compensate for.
+- The Smart MCP gateway `engraphis_remember` now forwards `subject_key` and
+  `claim_kind` end to end, matching the **Added** entry above.
 
 ### Operational
 


### PR DESCRIPTION
Follow-up to #171. 3rd-pass review (8-agent audit) flagged five phrases in the
PR1 [Unreleased] CHANGELOG entry that, taken together, broadcast a now-fixed
weakness with a reproducible fingerprint and read as a regression target for
anyone who can replay the eval pipeline.

The user memory paraphrases the pre-flagged "Do not broadcast security
improvements or vulnerable details in changelogs" rule. Headline numbers the
user wants preserved (k=50, savings_ratio 0.0 -> 0.4975, 35/36, 0/36, MRR 0.944 /
0.981, ~15 ms, 5/5 vs 0/5) are unchanged.

Concrete redactions, by line in the original PR1 CHANGELOG:
- Line 17 (Added): drops the "Without this, every keyed write silently stored
  empty keys" re-narration; capability sentence kept.
- Line 39 (Changed): drops the "(was 1/5 on the unkeyed benchmark pairs)"
  parenthetical. 35/36 and 0/36 numbers stay.
- Line 35 (Changed): reframes "without a stable `subject_key`" as a positive
  capability description (aligned token-diff contract with explicit vetoes).
- Line 53 (Fixed): drops "this is the underlying cause of the benchmark
  correction-miss pattern that the reworded-correction detector then had to
  compensate for."

Also adds one line to the cross-encoder bullet naming `.env` and the restart
step explicitly, so the operator-facing enablement is unambiguous (per A2's
readiness review).

CHANGELOG.md only. +14 -18. Targeting `ship/pr1-core-and-integration` (the
PR1 branch, current tip 6cdfc57). Owner-authored sections of CHANGELOG.md
(Galaxy/dashboard/graph entries) are unchanged.
