### PR TITLE
feat(storage): D-drive-first default data dir + guided database move from the dashboard

### DIFF
--- a/engraphis/config.py
+++ b/engraphis/config.py
@@ -29,7 +29,10 @@ from engraphis.private_state import (
 
 _logger = logging.getLogger("engraphis.config")
 
-_MAX_CONFIG_ENV_BYTES = 1024 * 1024
+#: Public cap for trusted-env parsing/rewriting; routes and tooling import this so the
+#: limit lives in exactly one place.
+MAX_CONFIG_ENV_BYTES = 1024 * 1024
+_MAX_CONFIG_ENV_BYTES = MAX_CONFIG_ENV_BYTES
 _CONFIG_ENV_ASSIGNMENT = re.compile(
     r"(?:export[ \t]+)?([A-Z][A-Z0-9_]*)[ \t]*=(.*)"
 )
@@ -162,6 +165,57 @@ def _load_trusted_dotenv() -> None:
 
 _load_trusted_dotenv()
 
+#: Drive roots preferred for first-run data placement on Windows, in order. A
+#: second internal drive beats crowding the system drive; both must be opt-out.
+_WINDOWS_PREFERRED_DATA_DRIVES = ("D", "E")
+
+
+def _default_data_dir(*, os_name: Optional[str] = None, platform: Optional[str] = None,
+                      environ: Optional[dict] = None, home: Optional[Path] = None) -> Path:
+    """Default root for Engraphis-owned persisted state (database, exports, caches).
+
+    ``ENGRAPHIS_DATA_DIR`` wins when set, so relocating everything to another drive is
+    one setting. Otherwise: on Windows prefer ``<D|E>:\\EngraphisData`` when such a
+    drive exists (keeps multi-GB databases off the system disk by default) and fall
+    back to the platform user-data directory; macOS and XDG platforms keep their
+    established locations so existing installs never silently change.
+    """
+    os_name = os.name if os_name is None else os_name
+    platform = sys.platform if platform is None else platform
+    environment = os.environ if environ is None else environ
+    home = Path.home() if home is None else home
+    configured = environment.get("ENGRAPHIS_DATA_DIR", "").strip()
+    if configured:
+        expanded = Path(configured).expanduser()
+        if (expanded.is_absolute()
+                or PurePosixPath(configured).is_absolute()
+                or PureWindowsPath(configured).is_absolute()):
+            # Preserve explicit spelling (including Windows drive paths checked from
+            # any host OS) instead of anchoring it to the caller's home.
+            return expanded
+        return home / expanded
+    if os_name == "nt":
+        for drive in _WINDOWS_PREFERRED_DATA_DRIVES:
+            drive_root = "%s:\\" % drive
+            try:
+                present = os.path.exists(drive_root)
+            except OSError:
+                present = False
+            if present:
+                return PureWindowsPath(drive_root) / "EngraphisData"
+        win_home = PureWindowsPath(str(home))
+        base = PureWindowsPath(
+            environment.get("LOCALAPPDATA") or (win_home / "AppData" / "Local")
+        )
+        return base / "engraphis"
+    posix_home = PurePosixPath(str(home).replace("\\", "/"))
+    if platform == "darwin":
+        return posix_home / "Library" / "Application Support" / "engraphis"
+    return PurePosixPath(
+        environment.get("XDG_DATA_HOME") or (posix_home / ".local" / "share")
+    ) / "engraphis"
+
+
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 _DEFAULT_DB_NOTICES = set()
 _WINDOWS_LOCK_RETRY_SECONDS = 0.05
@@ -182,20 +236,12 @@ def _default_db_path(root: Path = _PROJECT_ROOT, *, os_name: Optional[str] = Non
     platform = sys.platform if platform is None else platform
     environment = os.environ if environ is None else environ
     home = Path.home() if home is None else home
-    if os_name == "nt":
-        win_home = PureWindowsPath(str(home))
-        base = PureWindowsPath(
-            environment.get("LOCALAPPDATA") or (win_home / "AppData" / "Local")
-        )
-    elif platform == "darwin":
-        posix_home = PurePosixPath(str(home).replace("\\", "/"))
-        base = posix_home / "Library" / "Application Support"
-    else:
-        posix_home = PurePosixPath(str(home).replace("\\", "/"))
-        base = PurePosixPath(
-            environment.get("XDG_DATA_HOME") or (posix_home / ".local" / "share")
-        )
-    return str(base / "engraphis" / "engraphis.db")
+    # One data-root policy for every platform (ENGRAPHIS_DATA_DIR, Windows second-drive
+    # preference, then the established user-data directories) so the database default
+    # and Settings.data_dir can never disagree.
+    return str(_default_data_dir(
+        os_name=os_name, platform=platform, environ=environment, home=home,
+    ) / "engraphis.db")
 
 
 def _db_notice(key: str, message: str) -> None:
@@ -884,6 +930,13 @@ class Settings:
 
     db_path: str = field(
         default_factory=_configured_db_path
+    )
+
+    # Root for Engraphis-owned persisted state. Drives the default database location
+    # above and surfaces in the dashboard Storage panel; an explicit
+    # ENGRAPHIS_DB_PATH still wins over any default derived from it.
+    data_dir: str = field(
+        default_factory=lambda: str(_default_data_dir())
     )
 
     embed_model: str = field(

--- a/engraphis/dashboard_assets/index.html
+++ b/engraphis/dashboard_assets/index.html
@@ -612,6 +612,19 @@
                 <p>The preference stays on this device and is shared with Classic.</p>
                 <label>Theme<select id="theme-select"><option value="slate">Slate (dark)</option><option value="midnight">Midnight</option><option value="paper">Paper (light)</option><option value="matrix">Matrix</option></select></label>
               </section>
+              <section class="setting-card storage-setting-card">
+                <p class="eyebrow">Storage</p>
+                <h2>Where memory lives</h2>
+                <div id="storage-summary" class="storage-summary"><p class="empty-state">Checking storage…</p></div>
+                <label for="storage-dir-input">Folder for the database</label>
+                <input id="storage-dir-input" type="text" inputmode="text" autocomplete="off"
+                       spellcheck="false" placeholder="e.g. D:\\EngraphisData">
+                <p id="storage-hint" class="storage-hint">Moving copies the database, verifies it, then switches over. The choice is saved for every app that uses Engraphis.</p>
+                <div class="storage-actions">
+                  <button id="storage-move-btn" class="primary-button" type="button">Save &amp; move database</button>
+                  <span id="storage-result" class="storage-result" role="status" aria-live="polite"></span>
+                </div>
+              </section>
               <section class="setting-card">
                 <p class="eyebrow">Pro · hosted account</p>
                 <h2>Engraphis Cloud</h2>

--- a/engraphis/dashboard_assets/ledger.css
+++ b/engraphis/dashboard_assets/ledger.css
@@ -1320,3 +1320,12 @@ div[data-graph-style]:focus-visible {
   outline: 2px solid var(--c-acc);
   outline-offset: -2px;
 }
+
+/* Storage card — location summary + move control */
+.storage-setting-card .storage-summary { margin: 0; padding: 8px 10px; border: 1px solid var(--c-line); border-radius: 10px; background: var(--c-surface); color: var(--c-mid); font-size: .84rem; }
+.storage-setting-card .storage-summary strong { color: var(--c-fg); word-break: break-all; }
+.storage-setting-card label { font-size: .82rem; color: var(--c-mid); }
+.storage-setting-card input[type="text"] { width: 100%; padding: 8px 10px; border: 1px solid var(--c-line2); border-radius: 8px; background: var(--c-bg); color: var(--c-fg); font: inherit; }
+.storage-actions { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.storage-result[data-tone="error"] { color: var(--c-bad); font-size: .84rem; }
+.storage-result[data-tone="ready"] { color: var(--c-fg); font-size: .84rem; }

--- a/engraphis/dashboard_assets/ledger.js
+++ b/engraphis/dashboard_assets/ledger.js
@@ -3771,7 +3771,7 @@
 
   async function loadManageTab(tab) {
     if (tab === 'workspaces') renderWorkspaceList();
-    if (tab === 'settings') await loadSettings();
+    if (tab === 'settings') { await loadSettings(); await loadStoragePanel(); }
     if (tab === 'plans') await loadPlans();
     if (tab === 'analytics') await loadHosted('analytics');
     if (tab === 'automation') await loadHosted('automation');
@@ -4394,6 +4394,89 @@
     }
   }
 
+  function formatBytes(bytes) {
+    if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    let value = bytes;
+    let unit = 0;
+    while (value >= 1024 && unit < units.length - 1) { value /= 1024; unit += 1; }
+    return `${value >= 10 || unit === 0 ? Math.round(value) : value.toFixed(1)} ${units[unit]}`;
+  }
+
+  async function loadStoragePanel() {
+    const summary = byId('storage-summary');
+    if (!summary) return;
+    try {
+      const storage = await api('/storage');
+      state.storage = storage;
+      if (storage.db_exists) {
+        const p = node('p', '', '');
+        p.append('Database: ');
+        const strong = document.createElement('strong');
+        strong.textContent = storage.db_path;
+        p.append(strong, ` (${formatBytes(storage.db_bytes)})`);
+        const meta = node('p', '', '');
+        meta.textContent = `Configured data root: ${storage.data_dir}`;
+        const cfg = node('p', '', '');
+        cfg.textContent = `Settings file: ${storage.config_env}`;
+        const health = node('p', '', '');
+        health.textContent = storage.writable
+          ? 'Location is writable.'
+          : 'Warning: current location is not writable.';
+        summary.replaceChildren(p, meta, cfg, health);
+      } else {
+        const p = node('p', '', '');
+        p.textContent = `Database file not created yet (${storage.db_path}). `
+          + 'The first memory will create it.';
+        summary.replaceChildren(p);
+      }
+    } catch (error) {
+      summary.replaceChildren(empty(`Storage info unavailable: ${error.message}`));
+    }
+  }
+
+  async function moveDatabase() {
+    const input = byId('storage-dir-input');
+    const result = byId('storage-result');
+    const destination = (input.value || '').trim();
+    result.dataset.tone = '';
+    result.textContent = '';
+    if (!destination) {
+      result.dataset.tone = 'error';
+      result.textContent = 'Enter a folder path first.';
+      return;
+    }
+    const confirmed = window.confirm(
+      `Move the Engraphis database to ${destination}? `
+      + 'The app pauses briefly while the database is copied and verified. '
+      + 'The original stays untouched until the copy passes its integrity check.',
+    );
+    if (!confirmed) return;
+    const moveButton = byId('storage-move-btn');
+    moveButton.disabled = true;
+    result.textContent = 'Moving and verifying…';
+    try {
+      const outcome = await api('/storage/db-path', { method: 'POST', body: { destination_dir: destination } });
+      if (outcome.persisted === false) {
+        result.dataset.tone = 'error';
+        result.textContent = outcome.persist_error || 'Moved, but saving the choice failed.';
+      } else if (outcome.note) {
+        result.dataset.tone = 'ready';
+        result.textContent = outcome.note;
+      } else {
+        result.dataset.tone = 'ready';
+        result.textContent = `Database moved to ${outcome.moved_to}.`;
+      }
+      await loadStoragePanel();
+      await refreshBootstrap();
+    } catch (error) {
+      result.dataset.tone = 'error';
+      result.textContent = error.message;
+    } finally {
+      moveButton.disabled = false;
+    }
+  }
+
   async function loadSettings() {
     try {
       state.license = await api('/license');
@@ -4582,6 +4665,8 @@
   }));
   all('[data-provenance-tab]').forEach(control => control.addEventListener('click', () => switchProvenanceTab(control.dataset.provenanceTab)));
   all('[data-manage-tab]').forEach(control => control.addEventListener('click', () => switchManageTab(control.dataset.manageTab)));
+  const storageMoveButton = byId('storage-move-btn');
+  if (storageMoveButton) storageMoveButton.addEventListener('click', () => moveDatabase());
   function wireTabKeyboard(selector, dataKey, activate) {
     const controls = all(selector);
     controls.forEach((control, index) => {

--- a/engraphis/routes/v2_api.py
+++ b/engraphis/routes/v2_api.py
@@ -15,12 +15,13 @@ import hmac
 import logging
 import math
 import os
+import sqlite3
 import threading
 import time
 import urllib.error
 import urllib.request
 import weakref
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Optional
 from urllib.parse import quote
 
@@ -29,7 +30,15 @@ from pydantic import BaseModel, Field, StrictInt
 from starlette.concurrency import run_in_threadpool
 
 from engraphis import licensing
-from engraphis.config import DEFAULT_RELAY_URL, canonicalize_relay_url, settings
+from engraphis.config import (
+    DEFAULT_RELAY_URL,
+    MAX_CONFIG_ENV_BYTES,
+    _backup_sqlite,
+    canonicalize_relay_url,
+    settings,
+    trusted_env_path,
+)
+from engraphis.private_state import atomic_private_text, read_private_text
 from engraphis.core.poisoning import prompt_eligible
 from engraphis.core.scoring import normalize
 from engraphis.service import (
@@ -113,22 +122,27 @@ def _sanitized_http_exception(status_code: object) -> HTTPException:
     return HTTPException(status_code=500, detail={"error": "internal server error"})
 
 
+def _build_service(db_path: str) -> MemoryService:
+    """Construct the process-default service for *db_path* (shared by lazy bind + moves)."""
+    return MemoryService.create(
+        db_path, embed_model=settings.embed_model,
+        embed_revision=getattr(settings, "embed_revision", "") or None,
+        require_immutable_models=bool(
+            getattr(settings, "require_immutable_models", False)
+        ),
+        embed_dim=settings.embed_dim if settings.embed_dim is not None else 384,
+        vector_backend=settings.vector_backend,
+        rerank_model=getattr(settings, "rerank_model", "") or None,
+        rerank_revision=getattr(settings, "rerank_revision", "") or None,
+    )
+
+
 def service() -> MemoryService:
     """Lazily bind a single MemoryService to the configured store (the live v2 DB)."""
     global _service
     with _SERVICE_LOCK:
         if _service is None:
-            _service = MemoryService.create(
-                settings.db_path, embed_model=settings.embed_model,
-                embed_revision=getattr(settings, "embed_revision", "") or None,
-                require_immutable_models=bool(
-                    getattr(settings, "require_immutable_models", False)
-                ),
-                embed_dim=settings.embed_dim if settings.embed_dim is not None else 384,
-                vector_backend=settings.vector_backend,
-                rerank_model=getattr(settings, "rerank_model", "") or None,
-                rerank_revision=getattr(settings, "rerank_revision", "") or None,
-            )
+            _service = _build_service(settings.db_path)
         return _service
 
 
@@ -579,6 +593,8 @@ def bootstrap():
         "workspaces": wss,
         "stats": bootstrap_stats,
         "embedder": emb,
+        # Where data lives right now; the Settings -> Storage card renders from this.
+        "storage": _storage_snapshot(),
         # Non-blocking best-known update snapshot; the dashboard renders an "update
         # available" banner from this and a background refresh warms the cache.
         "update": _update_snapshot(),
@@ -3714,6 +3730,234 @@ def hosted_license_only():
 def hosted_trial_status(claim_id: str):
     del claim_id
     raise HTTPException(status_code=501, detail=_hosted_license_detail())
+
+
+# ── Storage location (dashboard Settings → Storage) ───────────────────────────────
+# The database lives wherever ENGRAPHIS_DB_PATH (trusted config.env) points, defaulting
+# through config._default_data_dir(). These routes expose that location and provide a
+# guided move: validate destination -> stop-the-world copy via the SQLite backup API ->
+# atomically persist the new absolute path in config.env so every entrypoint follows.
+
+
+def _dir_size(path: Path) -> int:
+    total = 0
+    try:
+        for entry in path.rglob("*"):
+            try:
+                if entry.is_file():
+                    total += entry.stat().st_size
+            except OSError:
+                continue
+    except OSError:
+        pass
+    return total
+
+
+def _storage_snapshot() -> dict:
+    """Best-effort view of where data lives and what it costs on disk."""
+    db = Path(settings.db_path).expanduser()
+    entry = {
+        "db_path": str(db),
+        "db_exists": False,
+        "db_bytes": 0,
+        "data_dir": settings.data_dir,
+        "state_dir": os.environ.get("ENGRAPHIS_STATE_DIR", "").strip(),
+        "config_env": str(trusted_env_path()),
+        "writable": False,
+    }
+    try:
+        entry["db_exists"] = db.is_file()
+        if entry["db_exists"]:
+            entry["db_bytes"] = db.stat().st_size
+            sidecars = sum(
+                side.stat().st_size
+                for side in (Path(str(db) + "-wal"), Path(str(db) + "-shm"))
+                if side.is_file()
+            )
+            entry["db_bytes"] += sidecars
+        target = db.parent if db.parent.exists() else Path(settings.data_dir)
+        probe = target / ".engraphis-write-probe"
+        probe.write_text("")
+        probe.unlink()
+        entry["writable"] = True
+    except OSError:
+        pass
+    return entry
+
+
+@router.get("/storage")
+def storage_info():
+    """Owner-facing storage snapshot for the dashboard Settings panel."""
+    return _storage_snapshot()
+
+
+class _StorageMoveReq(BaseModel):
+    destination_dir: str = Field(min_length=1)
+
+
+def _looks_like_windows_system_drive(text: str) -> bool:
+    """True when *text* names a path on the Windows system drive (C:).
+
+    Parsed with Windows semantics regardless of host OS, so a dashboard running on
+    POSIX still recognizes "C:\\Users" as the system drive instead of a relative
+    folder literally named "C:".
+    """
+    win = PureWindowsPath(text.replace("/", "\\"))
+    drive = win.drive
+    return win.is_absolute() and len(drive) >= 2 and drive[1] == ":" and drive[0].upper() == "C"
+
+
+def _resolve_move_destination(raw: str) -> Path:
+    text = raw.strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="Destination directory is empty.")
+    if _looks_like_windows_system_drive(text):
+        raise HTTPException(
+            status_code=400,
+            detail="Refusing to move onto the system drive (C:) — that is what this "
+                   "move exists to escape.",
+        )
+    if PureWindowsPath(text).is_absolute():
+        # A Windows drive path keeps its spelling on every host OS: resolving it with
+        # POSIX rules would silently turn "D:/X" into "<cwd>/D:/X".
+        return Path(str(PureWindowsPath(text)))
+    candidate = Path(text).expanduser()
+    if not (candidate.is_absolute() or PurePosixPath(text).is_absolute()):
+        candidate = Path.home() / candidate
+    try:
+        resolved = candidate.resolve(strict=False)
+    except OSError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid destination: {exc}")
+    return resolved
+
+
+@router.post("/storage/db-path")
+async def move_database(req: _StorageMoveReq):
+    """Relocate the active SQLite store to another directory and persist the choice.
+
+    Stop-the-world copy: readers/writers are drained first, then a validated backup-API
+    copy is published with ``os.replace`` (atomic on the same volume; cross-volume moves
+    fall back to copy+delete after verification). The chosen absolute path is written to
+    the trusted config file so MCP servers, CLI runs, and future dashboard starts all
+    follow it. A failure at any stage leaves the original database untouched.
+    """
+    dest_dir = _resolve_move_destination(req.destination_dir)
+    source = Path(settings.db_path).expanduser()
+    if not source.is_file():
+        raise HTTPException(status_code=409, detail="No existing database to move.")
+    try:
+        dest_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise HTTPException(status_code=400, detail=f"Cannot create destination: {exc}")
+    if not os.access(dest_dir, os.W_OK):
+        raise HTTPException(status_code=400, detail="Destination is not writable.")
+    target = dest_dir / source.name
+
+    if source.resolve() == target.resolve():
+        raise HTTPException(status_code=400,
+                            detail="Database already lives at that location.")
+    if target.exists():
+        raise HTTPException(
+            status_code=409,
+            detail="A file named %s already exists in the destination." % target.name,
+        )
+
+    # 1. Quiesce first so WAL content is checkpointed into the main file and no
+    #    connection can write mid-copy. set_service() closes under the same lock the
+    #    lazy binder uses, so nothing can reopen until step 4 publishes a new binding.
+    global _service
+    with _SERVICE_LOCK:
+        current = _service
+        if current is not None:
+            close = getattr(current, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception as exc:  # noqa: BLE001 - busy workers abort the move
+                    raise HTTPException(
+                        status_code=409,
+                        detail="Database is busy (background work did not stop in "
+                               "time): " + type(exc).__name__,
+                    )
+            _service = None
+
+    # 2. Copy to a randomized stage beside the DESTINATION and verify it.
+    try:
+        _backup_sqlite(source, target)
+    except FileExistsError:
+        with _SERVICE_LOCK:
+            _service = _build_service(str(source))
+        raise HTTPException(status_code=409, detail="Move already in progress.")
+    except Exception as exc:  # noqa: BLE001 - restore service, report
+        with _SERVICE_LOCK:
+            _service = _build_service(str(source))
+        raise HTTPException(status_code=500,
+                            detail="Copy failed; original untouched (%s)." % type(exc).__name__)
+    check_conn = sqlite3.connect(str(target), timeout=30)
+    try:
+        row = check_conn.execute("PRAGMA quick_check").fetchone()
+    finally:
+        check_conn.close()
+    if not row or row[0] != "ok":
+        try:
+            target.unlink()
+        except OSError:
+            pass
+        with _SERVICE_LOCK:
+            _service = _build_service(str(source))
+        raise HTTPException(
+            status_code=500,
+            detail="Copied database failed its integrity check; original kept.",
+        )
+
+    # 3. Publish. Same volume: atomic replace of the original. Cross volume: the verified
+    #    copy is authoritative, so remove the source after success (sidecars included).
+    try:
+        os.replace(str(source), str(target))
+        replaced_in_place = True
+    except OSError:
+        replaced_in_place = False
+    stale_original = None
+    if not replaced_in_place:
+        try:
+            source.unlink()
+        except OSError as exc:
+            # The new database is complete and verified; only the stale original lingers.
+            stale_original = str(exc)
+    for sidecar in ("-wal", "-shm"):
+        try:
+            Path(str(source) + sidecar).unlink()
+        except OSError:
+            pass
+
+    settings.db_path = str(target)
+
+    # 4. Rebind immediately so this process serves the new location without a restart.
+    with _SERVICE_LOCK:
+        _service = _build_service(str(target))
+    if stale_original is not None:
+        return {"ok": True, "moved_to": str(target), "persisted": None,
+                "note": "New database is live; could not delete the old file (%s). "
+                        "Delete it manually." % stale_original}
+
+    env_path = trusted_env_path()
+    try:
+        env_path.parent.mkdir(parents=True, exist_ok=True)
+        raw_text = ""
+        if env_path.is_file():
+            raw_text = read_private_text(env_path, max_bytes=MAX_CONFIG_ENV_BYTES,
+                                         allow_missing=True) or ""
+        lines = [
+            line for line in raw_text.splitlines()
+            if not line.strip().startswith("ENGRAPHIS_DB_PATH=")
+        ]
+        lines.append("ENGRAPHIS_DB_PATH=%s" % target)
+        atomic_private_text(env_path, "\n".join(lines) + "\n")
+    except Exception as exc:  # noqa: BLE001 - DB moved; surface only the persistence error
+        return {"ok": True, "moved_to": str(target),
+                "persisted": False,
+                "persist_error": "Set ENGRAPHIS_DB_PATH=%s manually (%s)" % (target, exc)}
+    return {"ok": True, "moved_to": str(target), "persisted": True}
 
 
 @router.post("/ops/backup")

--- a/tests/test_storage_location.py
+++ b/tests/test_storage_location.py
@@ -1,0 +1,139 @@
+"""Storage location feature: data-dir defaults, snapshot route, and guided DB move."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi", reason="storage routes need the server extra")
+
+from fastapi import FastAPI  # noqa: E402 - after importorskip guard (house pattern)
+from fastapi.testclient import TestClient  # noqa: E402
+
+from engraphis.routes import v2_api  # noqa: E402
+
+
+def _make_db(path: Path) -> None:
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute("CREATE TABLE memories (id TEXT PRIMARY KEY, content TEXT)")
+        conn.execute("INSERT INTO memories VALUES ('m1', 'hello')")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class _StubStore:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class _StubService:
+    """Route-level double: exposes the close() contract the move relies on."""
+
+    def __init__(self) -> None:
+        self.store = _StubStore()
+
+    def close(self) -> None:
+        self.store.closed = True
+
+
+def _client(monkeypatch, tmp_path, db_path):
+    monkeypatch.setattr(v2_api.settings, "db_path", str(db_path))
+    monkeypatch.setattr(v2_api.settings, "data_dir", str(tmp_path / "dataroot"))
+    env_file = tmp_path / "config.env"
+    monkeypatch.setattr(v2_api, "trusted_env_path", lambda: env_file)
+    app = FastAPI()
+    app.include_router(v2_api.router)
+    return TestClient(app), env_file
+
+
+def test_storage_snapshot_reports_location_and_writability(monkeypatch, tmp_path):
+    db_path = tmp_path / "source" / "engraphis.db"
+    db_path.parent.mkdir()
+    _make_db(db_path)
+    client, _ = _client(monkeypatch, tmp_path, db_path)
+
+    response = client.get("/api/storage")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["db_path"] == str(db_path)
+    assert body["db_exists"] is True
+    assert body["db_bytes"] > 0
+    assert body["writable"] is True
+    assert body["data_dir"] == str(tmp_path / "dataroot")
+
+
+def test_move_relocates_database_and_persists_choice(monkeypatch, tmp_path):
+    source_dir = tmp_path / "on-c"
+    dest_dir = tmp_path / "on-d"
+    source_dir.mkdir()
+    db_path = source_dir / "engraphis.db"
+    _make_db(db_path)
+
+    stub = _StubService()
+    client, env_file = _client(monkeypatch, tmp_path, db_path)
+    v2_api.set_service(stub)
+    rebuilt = {}
+    real_build = v2_api._build_service
+
+    def fake_build(db_path_arg):
+        rebuilt["path"] = db_path_arg
+        return real_build(":memory:") if False else _StubService()
+
+    monkeypatch.setattr(v2_api, "_build_service", fake_build)
+    try:
+        response = client.post(
+            "/api/storage/db-path", json={"destination_dir": str(dest_dir)}
+        )
+    finally:
+        v2_api._service = None
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is True
+    assert body["moved_to"] == str(dest_dir / "engraphis.db")
+    assert body["persisted"] is True
+
+    # Database physically relocated with its content intact.
+    assert not db_path.exists()
+    moved = dest_dir / "engraphis.db"
+    check = sqlite3.connect(str(moved))
+    try:
+        rows = check.execute("SELECT count(*) FROM memories").fetchone()
+    finally:
+        check.close()
+    assert rows[0] == 1
+
+    # Choice persisted to the TRUSTED env file as an absolute assignment.
+    text = env_file.read_text(encoding="utf-8")
+    assert "ENGRAPHIS_DB_PATH=%s" % moved in text
+
+    # Live binding was switched to the new location without a restart.
+    assert rebuilt["path"] == str(moved)
+    assert stub.store.closed is True
+
+
+def test_move_refuses_system_drive_destination(monkeypatch, tmp_path):
+    db_path = tmp_path / "engraphis.db"
+    _make_db(db_path)
+    client, _ = _client(monkeypatch, tmp_path, db_path)
+
+    for payload in ("C:/Users/nobody/x", "C:\\Users\\nobody", "c:/temp"):
+        response = client.post(
+            "/api/storage/db-path", json={"destination_dir": payload}
+        )
+        assert response.status_code == 400, payload
+        assert "system drive" in response.json()["detail"]
+
+
+def test_move_windows_absolute_paths_resolve_without_home_anchoring(tmp_path):
+    """A Windows-style non-system destination (D:) stays drive-absolute on any host."""
+    from engraphis.routes.v2_api import _resolve_move_destination
+
+    resolved = _resolve_move_destination("D:/EngraphisData")
+    assert str(resolved).lower().startswith("d:")


### PR DESCRIPTION
## What

Adds a first-class **storage location** story:

1. **Better defaults, less C: bloat** — on Windows, a first-run installed build now places its database at `D:\EngraphisData\engraphis.db` when a `D:` drive exists (`E:` as second preference), falling back to the established `LOCALAPPDATA` path otherwise. macOS/XDG locations are unchanged.
2. **One knob for everything** — new `ENGRAPHIS_DATA_DIR` overrides the data root on every platform; the DB default and the new dashboard Storage panel derive from the same `_default_data_dir()` so they can never disagree. Explicit `ENGRAPHIS_DB_PATH` still wins.
3. **Directory picker in the web UI** — Settings → Storage card shows where the database lives right now (path, size incl. WAL sidecars, writability) and offers a folder input + **Save & move database**.
4. **Guided move backend** — `POST /api/storage/db-path`:
   - validates the destination (refuses anything on the system drive `C:` — that's what the feature exists to escape),
   - quiesces the live service under the same lock the lazy binder uses,
   - copies via the SQLite backup API into a randomized stage file and runs `quick_check`,
   - publishes atomically (same-volume `os.replace`; cross-volume verified copy then source removal),
   - rebinds the running service without a restart,
   - persists the absolute path into the trusted owner-private `config.env` via `atomic_private_text`, so MCP servers, CLI runs, and future launches all follow.

`GET /api/storage` exposes the snapshot; `/api/bootstrap` carries it too.

## Notes

- Windows drive paths keep their verbatim spelling regardless of host OS (parsed with `PureWindowsPath`), so the C:-guard can't be bypassed or mangled by POSIX resolution of `"D:/X"`-style inputs.
- A failed copy leaves the original untouched; a failed config rewrite is reported per-field (`persisted: false`) instead of failing the whole move.

## Verification

- `python -m pytest tests/ -q --ignore=tests/e2e` → exit 0 (full offline suite)
- new `tests/test_storage_location.py`: end-to-end relocation (file moved, content intact, `ENGRAPHIS_DB_PATH` written to sandboxed trusted env, live binding switched), system-drive refusal (`C:/…`, `C:\…`, `c:/…`), snapshot contract
- `ruff check` clean on touched files; `check_commercial_manifest.py` OK; strict-CSP asset script passes (no inline JS added); served dashboard smoke-test renders the card and answers `/api/storage`
