### PR TITLE
test(decay): deflake reinforced-memory guard against coarse clocks

### DIFF
--- a/tests/test_decay_idempotent.py
+++ b/tests/test_decay_idempotent.py
@@ -67,10 +67,18 @@ def test_reinforced_memory_is_not_decayed_that_interval(monkeypatch, tmp_path):
     decayed = _stability("ns", "hot")
     assert decayed < 5.0
     # Simulate reinforcement: the memory is accessed now (last_access moves past the anchor).
+    # Bump one second past the pass's anchor: time.time() can return the SAME
+    # value as the anchor on coarse-clock hosts (observed on Windows), and a
+    # last_access equal to the anchor makes the subsequent pass legitimately
+    # decay one tick's interval — a race, not the regression this pins.
     conn = get_conn()
     conn.execute("UPDATE memories SET last_access=? WHERE namespace=? AND document_id=?",
-                 (now_ts(), "ns", "hot"))
+                 (now + 1.0, "ns", "hot"))
     conn.commit()
     # A subsequent pass must NOT decay it further — it was just accessed.
     mem_store.apply_decay_to_all("ns", 7.0)
+    assert abs(_stability("ns", "hot") - decayed) < 1e-9
+    # And the guard must hold across many rapid passes, not just one.
+    for _ in range(50):
+        mem_store.apply_decay_to_all("ns", 7.0)
     assert abs(_stability("ns", "hot") - decayed) < 1e-9


### PR DESCRIPTION
## Problem

`tests/test_decay_idempotent.py::test_reinforced_memory_is_not_decayed_that_interval` failed intermittently in full-suite runs on this Windows host:

```
AssertionError: assert 2.1281674200679393e-09 < 1e-09
```

It always passed in isolation.

## Root cause

The test simulated reinforcement with `last_access = now_ts()` immediately after a decay pass had written `last_decay = now_ts()` as its anchor. On hosts with coarse clock resolution (consecutive `time.time()` calls can return the **same** value — observed on Windows), `last_access == last_decay`, so the production guard

```python
if last_access > anchor:   # strict >
```

does not fire, and the pass legitimately decays one clock tick's interval. At a 7-day half-life, one ~1 ms tick decays stability by ~2.1e-9 — just over the test's `1e-9` bit-identity threshold. This is a test race against wall-clock granularity, **not** a recurrence of the compounding-decay regression the test exists to pin.

## Fix (test-only)

- Set `last_access = now + 1.0` (one second past the pass anchor) so the guard condition holds deterministically on every host, regardless of clock resolution.
- Extend coverage: assert the guard across **50 rapid subsequent passes**, not just the first one — that is the actual invariant (a reinforced memory is never decayed again until new real time passes).

No production code changed. The strict `>` guard is correct: with `last_access == anchor` on a first pass (`last_decay IS NULL`, anchor derived from `last_access`), the 10-day interval must decay; changing it to `>=` would break first-pass decay.

## Verification

- `tests/test_decay_idempotent.py` passes 8/8 consecutive runs (previously flaked ~1 in 3 full-suite runs).
- 20/20 same-tick stress trials: stability bit-identical across rapid passes.
- Full offline gate: `4503 passed, 39 skipped`, ruff clean, pyright 0 errors, all eval gates green.