### PR TITLE
fix(release): install all Playwright browsers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -464,7 +464,11 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e ".[test]" "uvicorn[standard]>=0.29"
           npm ci --ignore-scripts --omit=optional
-          npx playwright install --with-deps chromium
+          # The Playwright project runs dedicated Firefox and WebKit smoke
+          # projects as well as Chromium. Install every browser exercised by
+          # the release gate so a clean runner cannot fail for a missing
+          # executable after the Chromium-only install succeeds.
+          npx playwright install --with-deps chromium firefox webkit
       - name: Audit the root browser dependency lock
         run: npm audit --audit-level=high
       - name: Playwright desktop/mobile, keyboard, CSP, console, and axe checks


### PR DESCRIPTION
## Summary\n- install Chromium, Firefox, and WebKit for the release browser gate\n- prevent clean-runner failures for the Firefox/WebKit smoke projects\n\n## Evidence\nThe v1.7.3 release run passed 154 Chromium tests but failed only because Firefox and WebKit executables were not installed.\n\n## Validation\n- git diff --check\n- existing release run: 154 passed, 2 failed due missing browser executables\n\nThis is required before the trusted PyPI release can complete.