### PR TITLE
fix(release): pin grype evidence scanner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -589,6 +589,9 @@ jobs:
         uses: anchore/scan-action@27805bf3b4e84b4a5c980df22ed233c00390a439 # v7.4.2
         with:
           image: engraphis:release
+          # Keep the scanner version aligned with the public evidence schema
+          # and its fail-closed validation in scripts/release_evidence.py.
+          grype-version: v0.110.0
           fail-build: false
           severity-cutoff: high
           only-fixed: true

--- a/tests/test_release_infrastructure.py
+++ b/tests/test_release_infrastructure.py
@@ -226,6 +226,7 @@ def test_ci_and_release_audit_production_image_dependencies():
     assert "docker compose config --quiet" in release_docker
     assert "Audit production image dependencies" in release_docker
     assert "pip-audit==2.10.1" in release_docker
+    assert "grype-version: v0.110.0" in release_docker
     assert 'docker create --name "$container" engraphis:release' in release_docker
     assert 'docker cp "$container:$site_packages/."' in release_docker
     assert legacy_audit_path not in release_docker


### PR DESCRIPTION
## Summary\n- pin the release container scan to Grype v0.110.0\n- keep generated public release evidence aligned with scripts/release_evidence.py\n- add a regression assertion for the workflow pin\n\n## Root cause\nThe release run generated a Grype 0.118.0 report while the evidence contract intentionally accepts 0.110.0, so evidence generation failed closed after every code and platform gate passed.\n\n## Validation\n- tests/test_release_infrastructure.py\n- tests/test_release_evidence.py\n- git diff --check